### PR TITLE
Document Cursor Cloud dev environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,3 +74,41 @@ dotnet build LiteBus.slnx
 - Follow existing naming, project layout, and module patterns.
 - Keep changes scoped to the task.
 - Update `Changelog.md` under `v5.0.0` when public API or documented behavior changes.
+
+## Cursor Cloud specific instructions
+
+The VM has .NET SDKs 8, 9, and 10 installed (tests multi-target `net8.0;net9.0;net10.0`) and Docker.
+
+### Building and testing need public signing
+
+`src/LiteBus.Runtime` and `src/LiteBus.PostgreSql` declare `InternalsVisibleTo` with a fixed strong-name public key, so every project must be signed with that key to compile. The private key is the `STRONG_NAME_KEY` CI secret and is not available here. The workaround is OSS public signing against a public-key-only `LiteBus.snk` (git-ignored), which does not need the private key.
+
+The startup update script writes `LiteBus.snk` if it is missing, and `~/.bashrc` exports `SignAssembly=true`, `PublicSign=true`, and `AssemblyOriginatorKeyFile=/workspace/LiteBus.snk`. With those in place, the documented commands work unchanged:
+
+```bash
+dotnet build LiteBus.slnx   # also the StyleCop/XML-doc lint gate
+dotnet test LiteBus.slnx
+```
+
+If a shell does not pick up the exports (for example a stripped environment), pass them explicitly: `dotnet build LiteBus.slnx -p:SignAssembly=true -p:PublicSign=true -p:AssemblyOriginatorKeyFile=$PWD/LiteBus.snk`. Do not commit `LiteBus.snk`; committing it would flip on signing for contributors who lack the private key and break their builds.
+
+### PostgreSQL integration tests need a running Docker daemon
+
+`tests/LiteBus.PostgreSql.IntegrationTests` uses `Testcontainers.PostgreSql`, which starts a real PostgreSQL container. Docker is not managed by systemd here, so start the daemon manually if `docker info` fails:
+
+```bash
+sudo dockerd &
+```
+
+The first run pulls the `postgres` image. Unit-test projects have no Docker dependency.
+
+### Running the sample application
+
+`samples/LiteBus.Samples.NetCore` is an ASP.NET Core Web API exposing the `Orders` endpoints (`POST /api/Orders`, `GET /api/Orders/{id}`) backed by the command, query, and event modules. Run it in the Development environment for the Swagger UI at `/swagger`, and bind to HTTP to avoid the dev HTTPS certificate:
+
+```bash
+ASPNETCORE_ENVIRONMENT=Development ASPNETCORE_URLS=http://0.0.0.0:5080 \
+  dotnet run --project samples/LiteBus.Samples.NetCore
+```
+
+The `Failed to determine the https port for redirect` warning is expected with an HTTP-only binding and is harmless. The sample stores nothing: `GET` returns a generated `OrderDto`, while `POST` runs the full pipeline and writes `[PlaceOrderCommandHandler]` and `[OrderPlacedEventHandler]` lines to the console.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` so future cloud agents can build, test, and run LiteBus without rediscovering the non-obvious setup constraints. No product code changed.

## Why

Three things in this repo are not obvious from the existing docs and block a clean first run:

1. **Public signing is mandatory to compile.** `src/LiteBus.Runtime` and `src/LiteBus.PostgreSql` declare `InternalsVisibleTo` with a fixed strong-name public key. Every project must be signed with that key or the build fails with `CS0281`. The private key is the `STRONG_NAME_KEY` CI secret and is not present in the cloud VM. The section documents OSS public signing against a public-key-only `LiteBus.snk` (git-ignored), which needs no secret, plus the `SignAssembly`/`PublicSign`/`AssemblyOriginatorKeyFile` settings that make the documented `dotnet build`/`dotnet test` commands work unchanged.
2. **PostgreSQL integration tests need a running Docker daemon.** `tests/LiteBus.PostgreSql.IntegrationTests` uses `Testcontainers.PostgreSql`. Docker is not managed by systemd in the VM, so the daemon has to be started manually.
3. **Running the sample Web API.** How to launch `samples/LiteBus.Samples.NetCore` with Swagger in Development over HTTP, and why the HTTPS-redirect warning is benign.

## Verification

- `dotnet build LiteBus.slnx`: succeeds, 0 warnings (this is also the StyleCop/XML-doc lint gate).
- `dotnet test LiteBus.slnx`: all unit and PostgreSQL integration tests pass across `net8.0`, `net9.0`, and `net10.0`.
- Sample API hello-world: `POST /api/Orders` returns `201` with an order id and runs the full command + event pipeline; `GET /api/Orders/{id}` returns an `OrderDto`.

[litebus_sample_api_swagger_place_order.mp4](https://cursor.com/agents/bc-b4c6d71a-d306-457f-9992-52ac2fbb1744/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flitebus_sample_api_swagger_place_order.mp4)

Placing an order from the sample API Swagger UI (`POST /api/Orders` returns `201` with the new order id).

[Swagger UI showing a 201 response with the created order id](https://cursor.com/agents/bc-b4c6d71a-d306-457f-9992-52ac2fbb1744/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fswagger_place_order_201.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b4c6d71a-d306-457f-9992-52ac2fbb1744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b4c6d71a-d306-457f-9992-52ac2fbb1744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

