### PR TITLE
Redesign LiteBus landing page

### DIFF
--- a/site/app/globals.css
+++ b/site/app/globals.css
@@ -7,17 +7,15 @@
   --color-fd-primary-foreground: hsl(0, 0%, 100%);
   --litebus-charcoal: #3e3643;
   --litebus-yellow: #fdbf00;
-  --litebus-surface: color-mix(in oklab, var(--color-fd-card) 92%, var(--litebus-yellow) 8%);
-  --litebus-code-bg: #241f2b;
-  --litebus-code-fg: #e7e3ee;
-  --litebus-code-line: rgba(255, 255, 255, 0.08);
+  --litebus-code-bg: #211d26;
+  --litebus-code-fg: #e9e6ed;
+  --litebus-code-line: rgba(255, 255, 255, 0.09);
 }
 
 .dark {
   --color-fd-primary: hsl(45, 100%, 50%);
   --color-fd-primary-foreground: hsl(285, 11%, 18%);
-  --litebus-surface: color-mix(in oklab, var(--color-fd-card) 94%, var(--litebus-yellow) 6%);
-  --litebus-code-bg: #1c1822;
+  --litebus-code-bg: #1b181f;
 }
 
 body {
@@ -27,64 +25,59 @@ body {
     Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
 
-/* Layout shell -------------------------------------------------------------- */
+/* Landing page */
 
 .litebus-home {
   --litebus-width: 72rem;
   min-height: 100vh;
-  background:
-    radial-gradient(
-      42rem 32rem at 78% -8%,
-      color-mix(in oklab, var(--litebus-yellow) 20%, transparent),
-      transparent 70%
-    ),
-    radial-gradient(
-      36rem 30rem at 8% 4%,
-      color-mix(in oklab, var(--color-fd-primary) 14%, transparent),
-      transparent 72%
-    ),
-    var(--color-fd-background);
+  overflow-x: clip;
+  background: var(--color-fd-background);
 }
 
 .litebus-home-header {
   position: sticky;
   top: 0;
   z-index: 20;
+  border-bottom: 1px solid color-mix(in oklab, var(--color-fd-border) 78%, transparent);
+  background: color-mix(in oklab, var(--color-fd-background) 90%, transparent);
+  backdrop-filter: blur(14px);
+}
+
+.litebus-header-inner {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 1rem clamp(1rem, 5vw, 2rem);
-  border-bottom: 1px solid var(--color-fd-border);
-  background: color-mix(in oklab, var(--color-fd-background) 82%, transparent);
-  backdrop-filter: saturate(1.4) blur(12px);
+  width: min(var(--litebus-width), calc(100% - 3rem));
+  min-height: 4.25rem;
+  margin: 0 auto;
 }
 
 .litebus-brand {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: 0.6rem;
+  gap: 0.55rem;
   color: var(--color-fd-foreground);
-  font-size: 1.3rem;
-  font-weight: 750;
-  letter-spacing: -0.04em;
+  font-size: 1.15rem;
+  font-weight: 760;
+  letter-spacing: -0.035em;
   text-decoration: none;
 }
 
 .litebus-brand img {
-  width: 2rem;
-  height: 2rem;
+  width: 1.8rem;
+  height: 1.8rem;
 }
 
 .litebus-home-nav {
   display: flex;
   align-items: center;
-  gap: clamp(1rem, 3vw, 1.75rem);
+  gap: 1.7rem;
 }
 
 .litebus-home-nav a {
   color: var(--color-fd-muted-foreground);
-  font-size: 0.95rem;
-  font-weight: 600;
+  font-size: 0.9rem;
+  font-weight: 620;
   text-decoration: none;
   transition: color 0.15s ease;
 }
@@ -93,177 +86,190 @@ body {
   color: var(--color-fd-foreground);
 }
 
+.litebus-home-nav .nav-cta {
+  padding: 0.55rem 0.85rem;
+  border: 1px solid var(--color-fd-foreground);
+  border-radius: 0.45rem;
+  color: var(--color-fd-foreground);
+}
+
+.litebus-home-nav .nav-cta:hover {
+  background: var(--color-fd-foreground);
+  color: var(--color-fd-background);
+}
+
 .litebus-home main {
   width: min(var(--litebus-width), calc(100% - 3rem));
   margin: 0 auto;
 }
 
-/* Hero ---------------------------------------------------------------------- */
+/* Hero */
 
 .litebus-hero {
-  display: grid;
-  grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
-  align-items: center;
-  gap: clamp(2rem, 6vw, 4.5rem);
-  padding: clamp(3.5rem, 9vw, 7rem) 0 clamp(2.5rem, 5vw, 4rem);
-}
-
-.litebus-eyebrow {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
   align-items: center;
-  gap: 0.6rem;
-  margin-bottom: 1.4rem;
-  color: var(--color-fd-muted-foreground);
-  font-size: 0.85rem;
-  font-weight: 650;
-  letter-spacing: 0.01em;
+  padding: clamp(4.5rem, 8vw, 6rem) 0 clamp(4.5rem, 8vw, 6rem);
+  text-align: center;
 }
 
-.litebus-pill {
-  padding: 0.2rem 0.6rem;
+.litebus-hero-copy {
+  width: 100%;
+  max-width: 52rem;
+}
+
+.litebus-badges {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-bottom: 1.25rem;
+}
+
+.litebus-badges span {
+  padding: 0.3rem 0.65rem;
+  border: 1px solid var(--color-fd-border);
   border-radius: 999px;
-  background: var(--litebus-yellow);
-  color: var(--litebus-charcoal);
-  font-size: 0.72rem;
-  font-weight: 750;
+  color: var(--color-fd-muted-foreground);
+  font-size: 0.7rem;
+  font-weight: 700;
   letter-spacing: 0.06em;
   text-transform: uppercase;
 }
 
+.litebus-badges span:first-child {
+  border-color: color-mix(in oklab, var(--litebus-yellow) 55%, var(--color-fd-border));
+}
+
 .litebus-hero h1 {
-  margin: 0;
-  font-size: clamp(2.6rem, 6vw, 4.6rem);
-  font-weight: 780;
+  max-width: 52rem;
+  margin: 0 auto;
+  font-size: clamp(2.75rem, 4.8vw, 3.5rem);
+  font-weight: 775;
   letter-spacing: -0.05em;
-  line-height: 0.98;
+  line-height: 1;
 }
 
 .litebus-hero-copy > p {
-  max-width: 34rem;
-  margin-top: 1.4rem;
+  max-width: 43rem;
+  margin: 1.35rem auto 0;
   color: var(--color-fd-muted-foreground);
-  font-size: clamp(1.02rem, 1.6vw, 1.15rem);
-  line-height: 1.7;
+  font-size: clamp(1rem, 1.35vw, 1.1rem);
+  line-height: 1.75;
 }
 
 .litebus-actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem;
+  justify-content: center;
+  gap: 0.7rem;
   margin-top: 2rem;
 }
 
 .litebus-actions a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.8rem;
+  padding: 0.68rem 1rem;
   border: 1px solid var(--color-fd-border);
-  border-radius: 0.7rem;
-  padding: 0.72rem 1.1rem;
+  border-radius: 0.5rem;
   color: var(--color-fd-foreground);
-  font-size: 0.95rem;
-  font-weight: 650;
+  font-size: 0.9rem;
+  font-weight: 680;
   text-decoration: none;
   transition:
-    transform 0.15s ease,
+    background 0.15s ease,
     border-color 0.15s ease,
-    background 0.15s ease;
+    color 0.15s ease;
 }
 
 .litebus-actions a.primary {
   border-color: var(--litebus-yellow);
   background: var(--litebus-yellow);
   color: var(--litebus-charcoal);
-  box-shadow: 0 0.8rem 2rem color-mix(in oklab, var(--litebus-yellow) 35%, transparent);
 }
 
-.litebus-actions a:hover {
-  transform: translateY(-2px);
+.litebus-actions a.primary:hover {
+  border-color: color-mix(in oklab, var(--litebus-yellow) 82%, #000);
+  background: color-mix(in oklab, var(--litebus-yellow) 82%, #000);
 }
 
 .litebus-actions a:not(.primary):hover {
-  border-color: var(--color-fd-foreground);
+  border-color: var(--color-fd-muted-foreground);
+  background: color-mix(in oklab, var(--color-fd-muted) 70%, transparent);
 }
 
-.litebus-install-chip {
+.litebus-install {
   display: flex;
   align-items: center;
-  gap: 0.6rem;
+  justify-content: center;
+  gap: 0.55rem;
+  max-width: 100%;
   overflow-x: auto;
-  margin-top: 1.75rem;
-  padding: 0.7rem 0.9rem;
-  border: 1px solid var(--color-fd-border);
-  border-radius: 0.6rem;
-  background: var(--litebus-surface);
-  color: var(--color-fd-foreground);
+  margin: 1.35rem auto 0;
+  padding: 0.65rem 0;
+  color: var(--color-fd-muted-foreground);
   font-family: var(--font-mono, ui-monospace, 'SFMono-Regular', 'Menlo', monospace);
-  font-size: 0.82rem;
+  font-size: 0.73rem;
+  line-height: 1.5;
   white-space: nowrap;
 }
 
 .litebus-prompt {
   color: var(--litebus-yellow);
-  font-weight: 700;
+  font-weight: 750;
 }
 
-/* Code window --------------------------------------------------------------- */
+.litebus-hero-code {
+  width: min(100%, 50rem);
+  min-width: 0;
+  margin-top: clamp(2.5rem, 5vw, 3.25rem);
+  text-align: left;
+}
+
+/* Code example */
 
 .litebus-code {
   overflow: hidden;
   border: 1px solid var(--litebus-code-line);
-  border-radius: 0.9rem;
+  border-radius: 0.75rem;
   background: var(--litebus-code-bg);
-  box-shadow: 0 1.6rem 4rem color-mix(in oklab, #000 28%, transparent);
+  box-shadow: 0 1.5rem 4rem color-mix(in oklab, #000 22%, transparent);
 }
 
 .litebus-code-bar {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  padding: 0.65rem 0.9rem;
+  gap: 0.65rem;
+  padding: 0.7rem 0.95rem;
   border-bottom: 1px solid var(--litebus-code-line);
-  background: color-mix(in oklab, var(--litebus-code-bg) 82%, #000 18%);
 }
 
-.litebus-dots {
-  display: inline-flex;
-  gap: 0.4rem;
-}
-
-.litebus-dots i {
-  width: 0.7rem;
-  height: 0.7rem;
-  border-radius: 50%;
-  background: #4a4453;
-}
-
-.litebus-dots i:first-child {
-  background: #e06c5b;
-}
-
-.litebus-dots i:nth-child(2) {
-  background: #e0b24a;
-}
-
-.litebus-dots i:nth-child(3) {
-  background: #6cbf6c;
+.litebus-code-mark {
+  width: 0.52rem;
+  height: 0.52rem;
+  border-radius: 0.12rem;
+  background: var(--litebus-yellow);
 }
 
 .litebus-code-label {
-  color: #9a94a5;
+  color: #96909d;
   font-family: var(--font-mono, ui-monospace, 'SFMono-Regular', 'Menlo', monospace);
-  font-size: 0.78rem;
+  font-size: 0.74rem;
 }
 
 .litebus-code pre {
   overflow-x: auto;
   margin: 0;
-  padding: 1.1rem 1.25rem;
+  padding: 1.35rem 1.25rem 1.5rem;
 }
 
 .litebus-code code {
   color: var(--litebus-code-fg);
   font-family: var(--font-mono, ui-monospace, 'SFMono-Regular', 'Menlo', monospace);
-  font-size: 0.86rem;
-  line-height: 1.75;
+  font-size: clamp(0.72rem, 1vw, 0.8rem);
+  line-height: 1.82;
   white-space: pre;
 }
 
@@ -272,7 +278,7 @@ body {
 }
 
 .tok-t {
-  color: #6fb6ff;
+  color: #79baff;
 }
 
 .tok-s {
@@ -284,244 +290,184 @@ body {
 }
 
 .tok-c {
-  color: #7d7789;
+  color: #837d8c;
   font-style: italic;
 }
 
-/* Stats --------------------------------------------------------------------- */
-
-.litebus-stats {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 1px;
-  overflow: hidden;
-  border: 1px solid var(--color-fd-border);
-  border-radius: 1rem;
-  background: var(--color-fd-border);
-}
-
-.litebus-stat {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-  padding: 1.3rem 1.4rem;
-  background: var(--color-fd-background);
-}
-
-.litebus-stat-value {
-  color: var(--color-fd-foreground);
-  font-size: 1.05rem;
-  font-weight: 720;
-  letter-spacing: -0.02em;
-}
-
-.litebus-stat-label {
-  color: var(--color-fd-muted-foreground);
-  font-size: 0.82rem;
-}
-
-/* Generic section ----------------------------------------------------------- */
+/* Capabilities */
 
 .litebus-section {
-  padding: clamp(3.5rem, 8vw, 6rem) 0 0;
+  border-top: 1px solid var(--color-fd-border);
+  padding: clamp(5rem, 10vw, 8rem) 0;
 }
 
-.litebus-section-head {
-  max-width: 40rem;
-  margin-bottom: 2.5rem;
-}
-
-.litebus-section-head h2 {
-  margin: 0;
-  font-size: clamp(1.8rem, 3.4vw, 2.6rem);
-  font-weight: 760;
-  letter-spacing: -0.04em;
-  line-height: 1.05;
-}
-
-.litebus-section-head p {
-  margin: 1rem 0 0;
-  color: var(--color-fd-muted-foreground);
-  font-size: 1.05rem;
-  line-height: 1.7;
-}
-
-/* Features ------------------------------------------------------------------ */
-
-.litebus-features {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 1rem;
-}
-
-.litebus-feature {
-  padding: 1.6rem;
-  border: 1px solid var(--color-fd-border);
-  border-radius: 1rem;
-  background: color-mix(in oklab, var(--color-fd-card) 88%, transparent);
-  transition:
-    transform 0.15s ease,
-    border-color 0.15s ease;
-}
-
-.litebus-feature:hover {
-  transform: translateY(-3px);
-  border-color: color-mix(in oklab, var(--litebus-yellow) 55%, var(--color-fd-border));
-}
-
-.litebus-feature-icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 2.6rem;
-  height: 2.6rem;
-  margin-bottom: 1.1rem;
-  border-radius: 0.7rem;
-  background: color-mix(in oklab, var(--litebus-yellow) 18%, transparent);
-  color: color-mix(in oklab, var(--litebus-yellow) 78%, var(--color-fd-foreground));
-}
-
-.litebus-feature-icon svg {
-  width: 1.45rem;
-  height: 1.45rem;
-}
-
-.litebus-feature h3 {
-  margin: 0;
-  font-size: 1.1rem;
-  font-weight: 720;
-  letter-spacing: -0.01em;
-}
-
-.litebus-feature p {
-  margin: 0.6rem 0 0;
-  color: var(--color-fd-muted-foreground);
-  font-size: 0.94rem;
-  line-height: 1.65;
-}
-
-/* Showcase ------------------------------------------------------------------ */
-
-.litebus-showcase-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 1rem;
-  align-items: start;
-}
-
-/* Integrations -------------------------------------------------------------- */
-
-.litebus-integrations {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 1rem;
-}
-
-.litebus-integration-col {
-  padding: 1.5rem;
-  border: 1px solid var(--color-fd-border);
-  border-radius: 1rem;
-  background: color-mix(in oklab, var(--color-fd-card) 88%, transparent);
-}
-
-.litebus-integration-group {
+.litebus-section-label {
   display: block;
   margin-bottom: 1rem;
   color: var(--color-fd-muted-foreground);
-  font-size: 0.75rem;
+  font-size: 0.72rem;
   font-weight: 720;
   letter-spacing: 0.09em;
   text-transform: uppercase;
 }
 
-.litebus-integration-col ul {
-  display: flex;
-  flex-direction: column;
-  gap: 0.55rem;
+.litebus-section h2 {
   margin: 0;
-  padding: 0;
-  list-style: none;
-}
-
-.litebus-integration-col li {
-  position: relative;
-  padding-left: 1.2rem;
-  color: var(--color-fd-foreground);
-  font-size: 0.96rem;
-  font-weight: 550;
-}
-
-.litebus-integration-col li::before {
-  content: '';
-  position: absolute;
-  left: 0;
-  top: 0.5em;
-  width: 0.45rem;
-  height: 0.45rem;
-  border-radius: 50%;
-  background: var(--litebus-yellow);
-}
-
-/* CTA ----------------------------------------------------------------------- */
-
-.litebus-cta {
-  margin: clamp(4rem, 9vw, 7rem) 0 clamp(3rem, 6vw, 5rem);
-  padding: clamp(2.5rem, 6vw, 4rem);
-  border: 1px solid var(--color-fd-border);
-  border-radius: 1.4rem;
-  text-align: center;
-  background:
-    radial-gradient(
-      30rem 20rem at 50% -20%,
-      color-mix(in oklab, var(--litebus-yellow) 16%, transparent),
-      transparent 70%
-    ),
-    var(--litebus-surface);
-}
-
-.litebus-cta h2 {
-  max-width: 28rem;
-  margin: 0 auto;
-  font-size: clamp(1.7rem, 3.6vw, 2.6rem);
-  font-weight: 760;
-  letter-spacing: -0.04em;
+  font-size: clamp(2rem, 4vw, 3rem);
+  font-weight: 755;
+  letter-spacing: -0.048em;
   line-height: 1.05;
 }
 
-.litebus-cta p {
-  max-width: 34rem;
+.litebus-section-intro {
+  max-width: 42rem;
+  margin-right: auto;
+  margin-bottom: clamp(3rem, 6vw, 4.8rem);
+  margin-left: auto;
+  text-align: center;
+}
+
+.litebus-section-intro p {
   margin: 1rem auto 0;
   color: var(--color-fd-muted-foreground);
-  font-size: 1.05rem;
-  line-height: 1.6;
+  font-size: 1rem;
+  line-height: 1.7;
 }
 
-.litebus-cta .litebus-actions {
+.litebus-capability-list {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.8rem;
+}
+
+.litebus-capability {
+  display: flex;
+  flex-direction: column;
+  min-height: 13.5rem;
+  padding: 1.4rem;
+  border: 1px solid var(--color-fd-border);
+  border-radius: 0.8rem;
+  background: color-mix(in oklab, var(--color-fd-card) 72%, transparent);
+}
+
+.litebus-capability-icon {
+  display: inline-flex;
+  align-items: center;
   justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  margin-bottom: 1.4rem;
+  border: 1px solid color-mix(in oklab, var(--litebus-yellow) 35%, var(--color-fd-border));
+  border-radius: 0.5rem;
+  background: color-mix(in oklab, var(--litebus-yellow) 8%, transparent);
+  color: var(--litebus-yellow);
 }
 
-/* Footer -------------------------------------------------------------------- */
+.litebus-capability-icon svg {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.litebus-capability h3 {
+  margin: 0;
+  font-size: 1.02rem;
+  font-weight: 720;
+  letter-spacing: -0.02em;
+}
+
+.litebus-capability p {
+  margin: 0.7rem 0 0;
+  color: var(--color-fd-muted-foreground);
+  font-size: 0.86rem;
+  line-height: 1.62;
+}
+
+/* MediatR comparison */
+
+.litebus-mediatr {
+  display: grid;
+  grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
+  gap: clamp(2.5rem, 7vw, 6rem);
+  align-items: start;
+  padding: clamp(3.5rem, 7vw, 5rem) 0;
+  border-top: 1px solid var(--color-fd-border);
+}
+
+.litebus-mediatr h2 {
+  max-width: 28rem;
+  margin: 0;
+  font-size: clamp(1.8rem, 3.2vw, 2.35rem);
+  font-weight: 750;
+  letter-spacing: -0.04em;
+  line-height: 1.08;
+}
+
+.litebus-mediatr-copy p {
+  max-width: 38rem;
+  margin: 0 0 1rem;
+  color: var(--color-fd-muted-foreground);
+  font-size: 0.94rem;
+  line-height: 1.72;
+}
+
+.litebus-mediatr-copy a {
+  color: var(--color-fd-foreground);
+  font-size: 0.84rem;
+  font-weight: 680;
+  text-decoration: underline;
+  text-decoration-color: var(--litebus-yellow);
+  text-decoration-thickness: 0.12em;
+  text-underline-offset: 0.25em;
+}
+
+/* Footer */
 
 .litebus-footer {
+  border-top: 1px solid var(--color-fd-border);
+}
+
+.litebus-footer-inner {
   display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 1rem 2rem;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 3rem;
   width: min(var(--litebus-width), calc(100% - 3rem));
   margin: 0 auto;
-  padding: 2.5rem 0 3rem;
-  border-top: 1px solid var(--color-fd-border);
+  padding: 3rem 0 3.5rem;
+}
+
+.litebus-footer .litebus-brand {
+  font-size: 1rem;
+}
+
+.litebus-footer .litebus-brand img {
+  width: 1.45rem;
+  height: 1.45rem;
+}
+
+.litebus-footer p {
+  margin: 0.65rem 0 0;
+  color: var(--color-fd-muted-foreground);
+  font-size: 0.78rem;
+}
+
+.litebus-footer p a {
+  color: inherit;
+  text-decoration: underline;
+  text-underline-offset: 0.2em;
 }
 
 .litebus-footer nav {
   display: flex;
   flex-wrap: wrap;
-  gap: 1.25rem;
+  justify-content: flex-end;
+  gap: 0.8rem 1.4rem;
+  max-width: 34rem;
 }
 
 .litebus-footer nav a {
   color: var(--color-fd-muted-foreground);
-  font-size: 0.9rem;
+  font-size: 0.82rem;
   font-weight: 600;
   text-decoration: none;
 }
@@ -530,23 +476,7 @@ body {
   color: var(--color-fd-foreground);
 }
 
-.litebus-footer-note {
-  margin-left: auto;
-  color: var(--color-fd-muted-foreground);
-  font-size: 0.85rem;
-}
-
-.litebus-footer-note a {
-  color: var(--color-fd-foreground);
-  font-weight: 600;
-  text-decoration: none;
-}
-
-.litebus-footer-note a:hover {
-  text-decoration: underline;
-}
-
-/* Legal / privacy ----------------------------------------------------------- */
+/* Legal and privacy */
 
 .litebus-legal {
   max-width: 46rem;
@@ -586,11 +516,11 @@ body {
 }
 
 .litebus-legal ul {
-  margin: 0 0 1rem;
-  padding-left: 1.3rem;
   display: flex;
   flex-direction: column;
   gap: 0.7rem;
+  margin: 0 0 1rem;
+  padding-left: 1.3rem;
 }
 
 .litebus-legal a {
@@ -610,7 +540,7 @@ body {
   font-size: 0.9rem;
 }
 
-/* Docs nav brand (shared with docs layout) ---------------------------------- */
+/* Docs navigation brand */
 
 .litebus-nav-brand {
   display: inline-flex;
@@ -624,48 +554,99 @@ body {
   height: 1.5rem;
 }
 
-/* Responsive ---------------------------------------------------------------- */
+/* Focus */
+
+.litebus-home a:focus-visible {
+  outline: 2px solid var(--litebus-yellow);
+  outline-offset: 3px;
+}
+
+/* Responsive */
 
 @media (max-width: 960px) {
-  .litebus-features,
-  .litebus-integrations {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+  .litebus-hero {
+    padding: 4.75rem 0;
   }
 
-  .litebus-stats {
+  .litebus-hero-code {
+    max-width: 46rem;
+  }
+
+  .litebus-capability-list {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
-@media (max-width: 760px) {
-  .litebus-home main {
+@media (max-width: 720px) {
+  .litebus-header-inner,
+  .litebus-home main,
+  .litebus-footer-inner {
     width: min(100% - 2rem, var(--litebus-width));
   }
 
-  .litebus-hero {
-    grid-template-columns: 1fr;
-  }
-
-  .litebus-hero-code {
-    order: 2;
-  }
-
-  .litebus-showcase-grid,
-  .litebus-features,
-  .litebus-integrations {
-    grid-template-columns: 1fr;
+  .litebus-home-nav {
+    gap: 1rem;
   }
 
   .litebus-home-nav a:nth-child(2) {
     display: none;
   }
 
-  .litebus-footer {
-    width: min(100% - 2rem, var(--litebus-width));
+  .litebus-hero {
+    padding-top: 4.5rem;
   }
 
-  .litebus-footer-note {
-    margin-left: 0;
+  .litebus-capability {
+    min-height: 0;
+  }
+
+  .litebus-mediatr {
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+  }
+
+  .litebus-footer-inner {
+    flex-direction: column;
+  }
+
+  .litebus-footer nav {
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 560px) {
+  .litebus-home-nav > a:first-child {
+    display: none;
+  }
+}
+
+@media (max-width: 480px) {
+
+  .litebus-hero h1 {
+    font-size: 2.25rem;
+  }
+
+  .litebus-actions {
+    flex-direction: column;
+  }
+
+  .litebus-actions a {
     width: 100%;
+  }
+
+  .litebus-install {
+    margin-top: 1rem;
+    justify-content: flex-start;
+  }
+
+  .litebus-capability-list {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .litebus-home * {
+    scroll-behavior: auto;
+    transition-duration: 0.01ms !important;
   }
 }

--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -120,11 +120,7 @@ function CodeWindow({ label, code }: { label: string; code: string }) {
   return (
     <div className="litebus-code">
       <div className="litebus-code-bar">
-        <span className="litebus-dots" aria-hidden="true">
-          <i />
-          <i />
-          <i />
-        </span>
+        <span className="litebus-code-mark" aria-hidden="true" />
         <span className="litebus-code-label">{label}</span>
       </div>
       <pre>
@@ -134,77 +130,58 @@ function CodeWindow({ label, code }: { label: string; code: string }) {
   );
 }
 
-const REGISTER_CODE = `builder.Services.AddLiteBus(liteBus =>
+const QUICKSTART_CODE = `builder.Services.AddLiteBus(bus =>
 {
-    liteBus.AddMessaging(_ => { });
-    liteBus.AddCommands(c => c.RegisterFromAssembly(assembly));
-    liteBus.AddQueries(q => q.RegisterFromAssembly(assembly));
-    liteBus.AddEvents(e => e.RegisterFromAssembly(assembly));
-});`;
+    bus.AddMessaging(_ => { });
+    bus.AddCommands(commands =>
+        commands.RegisterFromAssembly(typeof(Program).Assembly));
+});
 
-const CONTRACT_CODE = `public sealed record CreateProduct(string Name, decimal Price)
-    : ICommand<Guid>;
-
-public sealed class CreateProductHandler
-    : ICommandHandler<CreateProduct, Guid>
-{
-    public Task<Guid> HandleAsync(CreateProduct command, CancellationToken ct)
-        => Task.FromResult(Guid.NewGuid());
-}`;
-
-const DISPATCH_CODE = `// inject the mediator for the operation you are performing
 var id = await mediator.SendAsync(
     new CreateProduct("Widget", 9.99m),
     cancellationToken);`;
 
-type Feature = { title: string; body: string; icon: ReactNode };
-
-const FEATURES: Feature[] = [
+const CAPABILITIES = [
   {
-    title: 'Semantic mediators',
-    body: 'Commands, queries, and events keep separate contracts, each with its own focused handler pipeline.',
-    icon: <path d="M4 6h7M4 12h16M4 18h10M15 4l3 3-3 3" />,
+    title: 'Commands and Queries',
+    body: 'Separate command and query mediators encode write and read intent for CQS applications.',
+    icon: <path d="M4 7h13m0 0-3-3m3 3-3 3M20 17H7m0 0 3-3m-3 3 3 3" />,
   },
   {
-    title: 'Reliable messaging',
-    body: 'Inbox, outbox, scheduling, retries, leases, and sagas compose as independent, opt-in concerns.',
-    icon: <path d="M12 3l8 4v5c0 4.5-3.2 7.6-8 9-4.8-1.4-8-4.5-8-9V7l8-4z" />,
+    title: 'Domain Events',
+    body: 'Publish plain .NET event types to zero or more handlers without requiring a shared event base class.',
+    icon: <path d="M8 18h8M10 21h4M6 15h12l-1.5-2.5V9a4.5 4.5 0 0 0-9 0v3.5L6 15Z" />,
   },
   {
-    title: 'Opt-in packaging',
-    body: 'Reference a broker or ORM SDK only when you select it. No hidden transitive dependencies enter your graph.',
-    icon: <path d="M12 3l8 4.5v9L12 21l-8-4.5v-9L12 3zM12 12l8-4.5M12 12v9M12 12L4 7.5" />,
+    title: 'Handler Pipelines',
+    body: 'Run validation and cross-cutting work through named pre-, post-, and error-handler stages.',
+    icon: <path d="M4 6h5m6 0h5M9 4v4m6 3v4M4 13h11m0 0h5M4 20h5m6 0h5M9 18v4" />,
   },
   {
-    title: 'Roslyn analyzers',
-    body: 'Diagnostics LB1001 through LB1017 catch handler and registration mistakes at compile time.',
-    icon: <path d="M12 3l2.6 5.3 5.9.9-4.3 4.1 1 5.8L12 16.9 6.8 19.1l1-5.8-4.3-4.1 5.9-.9L12 3z" />,
+    title: 'Durable Inbox',
+    body: 'Persist commands before deferred execution with leases, retries, receipts, and at-least-once delivery.',
+    icon: <path d="M4 5h16v14H4V5Zm4 8h2l2 2 2-2h2M12 4v7m0 0-3-3m3 3 3-3" />,
   },
   {
-    title: 'Built-in observability',
-    body: 'OpenTelemetry meters and traces for inbox, outbox, and transport register through each host adapter.',
-    icon: <path d="M3 12h4l3 7 4-14 3 7h4" />,
+    title: 'Transactional Outbox',
+    body: 'Store events with domain state through transactional writers, then publish them with an outbox processor.',
+    icon: <path d="M4 5h16v14H4V5Zm4 8h2l2 2 2-2h2M12 11V4m0 0-3 3m3-3 3 3" />,
   },
   {
-    title: 'Validated module graph',
-    body: 'The module registry resolves and validates the full dependency graph before build. Callback order never matters.',
-    icon: (
-      <path d="M6 4a2 2 0 100 4 2 2 0 000-4zM18 16a2 2 0 100 4 2 2 0 000-4zM18 4a2 2 0 100 4 2 2 0 000-4zM7 8v3a3 3 0 003 3h6M18 8v6" />
-    ),
+    title: 'Saga State',
+    body: 'Persist correlated state around inbox command dispatch with in-memory or PostgreSQL storage.',
+    icon: <path d="M7 7a3 3 0 1 0 0 6 3 3 0 0 0 0-6Zm10 4a3 3 0 1 0 0 6 3 3 0 0 0 0-6ZM9.5 8.5l5-2M9.5 12l4.8 2" />,
   },
-];
-
-const INTEGRATIONS: { group: string; items: string[] }[] = [
-  { group: 'Transport', items: ['AMQP / RabbitMQ', 'Apache Kafka', 'AWS SQS', 'Azure Service Bus'] },
-  { group: 'Storage', items: ['PostgreSQL', 'Entity Framework Core', 'In-memory'] },
-  { group: 'Hosting & telemetry', items: ['ASP.NET Core', 'OpenTelemetry', 'Health checks'] },
-];
-
-const STATS: { value: string; label: string }[] = [
-  { value: '.NET 10', label: 'Target framework' },
-  { value: 'Commands, Queries, Events', label: 'Separate contracts' },
-  { value: 'Inbox + Outbox', label: 'Durable messaging' },
-  { value: 'Opt-in', label: 'No hidden SDKs' },
+  {
+    title: 'Storage and Transport',
+    body: 'Select PostgreSQL, EF Core, in-memory, RabbitMQ, Kafka, AWS SQS, or Azure Service Bus through opt-in adapters.',
+    icon: <path d="M4 6c0-1.1 3.6-2 8-2s8 .9 8 2-3.6 2-8 2-8-.9-8-2Zm0 0v6c0 1.1 3.6 2 8 2s8-.9 8-2V6M4 12v6c0 1.1 3.6 2 8 2s8-.9 8-2v-6" />,
+  },
+  {
+    title: 'Hosting and Operations',
+    body: 'Run processors through host adapters and add OpenTelemetry, health checks, management endpoints, and analyzers.',
+    icon: <path d="M3 12h4l2.5-6 4 12 2.5-6h5M5 4h14M5 20h14" />,
+  },
 ];
 
 export default function HomePage() {
@@ -214,70 +191,68 @@ export default function HomePage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
       />
+
       <header className="litebus-home-header">
-        <Link className="litebus-brand" href="/">
-          <Image src="/icon.svg" alt="" width={32} height={32} />
-          <span>LiteBus</span>
-        </Link>
-        <nav className="litebus-home-nav" aria-label="Main navigation">
-          <Link href="/docs">Documentation</Link>
-          <Link href="/docs/getting-started">Get started</Link>
-          <Link href="https://github.com/litenova/LiteBus">GitHub</Link>
-        </nav>
+        <div className="litebus-header-inner">
+          <Link className="litebus-brand" href="/" aria-label="LiteBus home">
+            <Image src="/icon.svg" alt="" width={30} height={30} priority />
+            <span>LiteBus</span>
+          </Link>
+          <nav className="litebus-home-nav" aria-label="Main navigation">
+            <Link href="/docs">Documentation</Link>
+            <Link href="https://github.com/litenova/LiteBus">GitHub</Link>
+            <Link className="nav-cta" href="/docs/getting-started">
+              Get Started
+            </Link>
+          </nav>
+        </div>
       </header>
 
       <main>
         <section className="litebus-hero">
           <div className="litebus-hero-copy">
-            <div className="litebus-eyebrow">
-              <span className="litebus-pill">v6.0</span>
-              Mediator &amp; durable messaging for .NET
+            <div className="litebus-badges" aria-label="Project licensing">
+              <span>MIT Licensed</span>
+              <span>Open Source</span>
+              <span>.NET 10</span>
             </div>
-            <h1>Clean message pipelines without hidden coupling.</h1>
+            <h1>Message Mediation and Durable Processing for .NET</h1>
             <p>
-              Compose commands, queries, events, inbox, and outbox processing from explicit
-              contracts and opt-in adapters. Install only the capabilities your service runs.
+              LiteBus provides command, query, and event mediation for CQS and DDD applications,
+              with optional inbox, outbox, saga, storage, and transport modules.
             </p>
             <div className="litebus-actions">
               <Link className="primary" href="/docs/getting-started">
-                Get started
+                Getting Started
               </Link>
-              <Link href="/docs">Read the documentation</Link>
+              <Link href="/docs">Documentation</Link>
             </div>
-            <div className="litebus-install-chip" aria-label="Install command">
+            <div className="litebus-install" aria-label="Install command">
               <span className="litebus-prompt" aria-hidden="true">
                 $
               </span>
-              dotnet add package LiteBus.Commands.Extensions.Microsoft.DependencyInjection
+              <code>dotnet add package LiteBus.Extensions.Microsoft.DependencyInjection</code>
             </div>
           </div>
 
           <div className="litebus-hero-code">
-            <CodeWindow label="Program.cs" code={REGISTER_CODE} />
+            <CodeWindow label="Program.cs" code={QUICKSTART_CODE} />
           </div>
         </section>
 
-        <section className="litebus-stats" aria-label="At a glance">
-          {STATS.map((stat) => (
-            <div key={stat.label} className="litebus-stat">
-              <span className="litebus-stat-value">{stat.value}</span>
-              <span className="litebus-stat-label">{stat.label}</span>
-            </div>
-          ))}
-        </section>
-
-        <section className="litebus-section" aria-labelledby="features-heading">
-          <div className="litebus-section-head">
-            <h2 id="features-heading">Built from independent concerns</h2>
+        <section className="litebus-section litebus-capabilities" aria-labelledby="capabilities-heading">
+          <div className="litebus-section-intro">
+            <span className="litebus-section-label">Modules and Integrations</span>
+            <h2 id="capabilities-heading">What LiteBus Includes</h2>
             <p>
-              Each capability ships as its own package and stays out of the graphs that do not use
-              it. Add exactly what a service needs and nothing more.
+              LiteBus separates mediation, durable processing, adapters, and operational
+              integrations into independent packages.
             </p>
           </div>
-          <div className="litebus-features">
-            {FEATURES.map((feature) => (
-              <article key={feature.title} className="litebus-feature">
-                <span className="litebus-feature-icon" aria-hidden="true">
+          <div className="litebus-capability-list">
+            {CAPABILITIES.map((capability) => (
+              <article key={capability.title} className="litebus-capability">
+                <span className="litebus-capability-icon" aria-hidden="true">
                   <svg
                     viewBox="0 0 24 24"
                     fill="none"
@@ -286,81 +261,51 @@ export default function HomePage() {
                     strokeLinecap="round"
                     strokeLinejoin="round"
                   >
-                    {feature.icon}
+                    {capability.icon}
                   </svg>
                 </span>
-                <h3>{feature.title}</h3>
-                <p>{feature.body}</p>
+                <h3>{capability.title}</h3>
+                <p>{capability.body}</p>
               </article>
             ))}
           </div>
         </section>
 
-        <section className="litebus-section litebus-showcase" aria-labelledby="showcase-heading">
-          <div className="litebus-section-head">
-            <h2 id="showcase-heading">From contract to dispatch</h2>
+        <section className="litebus-mediatr" aria-labelledby="mediatr-heading">
+          <div>
+            <span className="litebus-section-label">MediatR Comparison</span>
+            <h2 id="mediatr-heading">An MIT-Licensed Alternative to MediatR</h2>
+          </div>
+          <div className="litebus-mediatr-copy">
             <p>
-              Define a message and one handler, then send it through the mediator built for that
-              operation. The same shape scales to queries, events, and durable processing.
+              MediatR 13 moved to dual commercial and open-source licensing and requires a license
+              key. LiteBus remains MIT licensed and free for commercial use, with a message model
+              designed around CQS and DDD.
             </p>
-          </div>
-          <div className="litebus-showcase-grid">
-            <CodeWindow label="Contracts.cs" code={CONTRACT_CODE} />
-            <CodeWindow label="Usage.cs" code={DISPATCH_CODE} />
-          </div>
-        </section>
-
-        <section className="litebus-section" aria-labelledby="integrations-heading">
-          <div className="litebus-section-head">
-            <h2 id="integrations-heading">Opt-in integrations</h2>
-            <p>
-              Brokers, stores, hosts, and observability adapters install on demand. An external SDK
-              enters your application only when you select that integration.
-            </p>
-          </div>
-          <div className="litebus-integrations">
-            {INTEGRATIONS.map((column) => (
-              <div key={column.group} className="litebus-integration-col">
-                <span className="litebus-integration-group">{column.group}</span>
-                <ul>
-                  {column.items.map((item) => (
-                    <li key={item}>{item}</li>
-                  ))}
-                </ul>
-              </div>
-            ))}
-          </div>
-        </section>
-
-        <section className="litebus-cta" aria-labelledby="cta-heading">
-          <h2 id="cta-heading">Start with the capability you need today.</h2>
-          <p>
-            Install one package, register it in a single callback, and grow the graph deliberately.
-          </p>
-          <div className="litebus-actions">
-            <Link className="primary" href="/docs/getting-started">
-              Get started
-            </Link>
-            <Link href="https://github.com/litenova/LiteBus">View on GitHub</Link>
+            <Link href="/docs/migration/mediatr-differences">Compare LiteBus and MediatR</Link>
           </div>
         </section>
       </main>
 
       <footer className="litebus-footer">
-        <div className="litebus-brand">
-          <Image src="/icon.svg" alt="" width={24} height={24} />
-          <span>LiteBus</span>
+        <div className="litebus-footer-inner">
+          <div>
+            <Link className="litebus-brand" href="/">
+              <Image src="/icon.svg" alt="" width={24} height={24} />
+              <span>LiteBus</span>
+            </Link>
+            <p>
+              A <Link href={companyUrl}>{companyName}</Link> project.
+            </p>
+          </div>
+          <nav aria-label="Footer navigation">
+            <Link href="/docs">Documentation</Link>
+            <Link href="/docs/getting-started">Get Started</Link>
+            <Link href="/docs/architecture">Architecture</Link>
+            <Link href="/privacy">Privacy</Link>
+            <Link href="https://github.com/litenova/LiteBus">GitHub</Link>
+          </nav>
         </div>
-        <nav aria-label="Footer navigation">
-          <Link href="/docs">Documentation</Link>
-          <Link href="/docs/getting-started">Get started</Link>
-          <Link href="/docs/architecture">Architecture</Link>
-          <Link href="/privacy">Privacy</Link>
-          <Link href="https://github.com/litenova/LiteBus">GitHub</Link>
-        </nav>
-        <span className="litebus-footer-note">
-          A <Link href={companyUrl}>{companyName}</Link> project.
-        </span>
       </footer>
     </div>
   );

--- a/site/app/privacy/page.tsx
+++ b/site/app/privacy/page.tsx
@@ -23,15 +23,17 @@ export default function PrivacyPage() {
   return (
     <div className="litebus-home">
       <header className="litebus-home-header">
-        <Link className="litebus-brand" href="/">
-          <Image src="/icon.svg" alt="" width={32} height={32} />
-          <span>LiteBus</span>
-        </Link>
-        <nav className="litebus-home-nav" aria-label="Main navigation">
-          <Link href="/docs">Documentation</Link>
-          <Link href="/docs/getting-started">Get started</Link>
-          <Link href={repositoryUrl}>GitHub</Link>
-        </nav>
+        <div className="litebus-header-inner">
+          <Link className="litebus-brand" href="/">
+            <Image src="/icon.svg" alt="" width={32} height={32} />
+            <span>LiteBus</span>
+          </Link>
+          <nav className="litebus-home-nav" aria-label="Main navigation">
+            <Link href="/docs">Documentation</Link>
+            <Link href="/docs/getting-started">Get Started</Link>
+            <Link href={repositoryUrl}>GitHub</Link>
+          </nav>
+        </div>
       </header>
 
       <main>
@@ -152,19 +154,23 @@ export default function PrivacyPage() {
       </main>
 
       <footer className="litebus-footer">
-        <div className="litebus-brand">
-          <Image src="/icon.svg" alt="" width={24} height={24} />
-          <span>LiteBus</span>
+        <div className="litebus-footer-inner">
+          <div>
+            <Link className="litebus-brand" href="/">
+              <Image src="/icon.svg" alt="" width={24} height={24} />
+              <span>LiteBus</span>
+            </Link>
+            <p>
+              A <Link href={companyUrl}>{companyName}</Link> project.
+            </p>
+          </div>
+          <nav aria-label="Footer navigation">
+            <Link href="/docs">Documentation</Link>
+            <Link href="/docs/getting-started">Get Started</Link>
+            <Link href="/privacy">Privacy</Link>
+            <Link href={repositoryUrl}>GitHub</Link>
+          </nav>
         </div>
-        <nav aria-label="Footer navigation">
-          <Link href="/docs">Documentation</Link>
-          <Link href="/docs/getting-started">Get started</Link>
-          <Link href="/privacy">Privacy</Link>
-          <Link href={repositoryUrl}>GitHub</Link>
-        </nav>
-        <span className="litebus-footer-note">
-          A <Link href={companyUrl}>{companyName}</Link> project.
-        </span>
       </footer>
     </div>
   );


### PR DESCRIPTION
## What Changed

- Reworked the landing page around a centered hero, a compact module grid, and a small MediatR comparison.
- Added MIT, open-source, and .NET 10 badges plus a runnable LiteBus registration example.
- Replaced numbered module cards with eight icon-led cards covering mediation, durability, integrations, and operations.
- Aligned the shared privacy-page header and footer markup with the new site shell.
- Added responsive four-, two-, and one-column card layouts.

## Why

The previous page repeated capabilities across multiple sections and gave each item too much visual weight. The new layout keeps the technical content visible while reducing the number of sections and the size of the hero.

## Impact

Documentation visitors get a shorter technical overview of LiteBus, its CQS and DDD message model, durable messaging modules, integrations, MIT license, and MediatR positioning. Documentation routes and application APIs are unchanged.

## Validation

- `npm run lint`
- `npm run build`
- Desktop and compact browser renders at `http://127.0.0.1:3100`