### PR TITLE
Configure Vercel deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,9 @@ site/node_modules/
 site/.next/
 site/*.tsbuildinfo
 
+# Vercel local project metadata
+.vercel/
+
 # Local tooling caches
 .fuse/
 

--- a/site/README.md
+++ b/site/README.md
@@ -35,3 +35,26 @@ The build and release workflows run a clean install, a high-severity dependency 
 linting, type checking, the production build, and the rendered-link gate. Changes under
 `site/` or `Roadmap/` trigger the build workflow. A separate content-mirror gate rejects
 missing, stale, or orphaned site pages before the Fumadocs build starts.
+
+## Vercel deployment
+
+Import the `litenova/LiteBus` repository as a Vercel project and set **Root Directory** to
+`site`. Leave the output directory unset so the Next.js preset can manage `.next`. The
+project does not require environment variables.
+
+The checked-in `vercel.json` pins the Next.js framework preset and uses `npm ci` followed
+by `npm run build`. The build includes the rendered-link and search-trace checks. Vercel
+reads Node.js 24 from `package.json`. Deployments are skipped when a commit has no changes
+under `site/`; a manual redeployment can bypass the ignored build step in the Vercel
+dashboard.
+
+Use these project settings:
+
+| Setting | Value |
+|---------|-------|
+| Root Directory | `site` |
+| Framework Preset | Next.js |
+| Install Command | `npm ci` from `vercel.json` |
+| Build Command | `npm run build` from `vercel.json` |
+| Output Directory | Framework default |
+| Node.js Version | `24.x` from `package.json` |

--- a/site/vercel.json
+++ b/site/vercel.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "installCommand": "npm ci",
+  "buildCommand": "npm run build",
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- ."
+}


### PR DESCRIPTION
## What Changed

- Added `site/vercel.json` with the Next.js preset, `npm ci`, the existing full build command, and a site-only ignored build check.
- Documented the Vercel project settings in `site/README.md`.
- Excluded local `.vercel` project metadata from Git.

## Why

The Next.js application is under `site` rather than the repository root. Vercel needs that directory selected as the project root. The checked-in configuration keeps dependency installation and build validation aligned with CI while avoiding builds for commits that do not change the site.

## Deployment Impact

Import `litenova/LiteBus` in Vercel and set **Root Directory** to `site`. The framework preset, install command, build command, output directory, and Node.js version then come from the repository configuration. No environment variables are required.

## Validation

- `npm ci`
- `npm audit --audit-level=high` (zero vulnerabilities)
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- 230 rendered documentation link checks
- 230 documentation files verified in the search route trace
