### PR TITLE
Fix event publish skipping concrete handlers on erased types (6.0.2)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## v6.0.2
+
+Patch release for .NET 10. Public APIs, persistence schemas, and transport behavior are unchanged.
+
+### Fixed
+
+- Publishing an event through a base-typed or interface-typed reference now invokes handlers registered for the concrete event type. `IEventMediator.PublishAsync(IEvent, ...)` and the `PublishAsync(@event, cancellationToken)` extension erase the event to `IEvent`, and because handler contracts are contravariant, `AsyncBroadcastMediationStrategy<TMessage>` matched only handlers registered for the erased type and skipped the rest without raising an error. Handlers whose contract does not close over the compile-time message type are now dispatched through the non-generic handler entry point, which routes to the closed contract the handler implements. This also restores in-process outbox dispatch, which publishes every `IEvent` through the non-generic overload.
+
 ## v6.0.1
 
 Documentation and policy maintenance release for .NET 10. Public APIs, persistence schemas, and transport behavior are unchanged.

--- a/scripts/Test-Packages.ps1
+++ b/scripts/Test-Packages.ps1
@@ -184,8 +184,8 @@ foreach ($package in $packageMetadata) {
         $errors.Add("Package '$($package.Id)' does not declare the LiteBus website as its project URL.")
     }
 
-    if ($null -eq $releaseNotes -or $releaseNotes.InnerText -ne "https://github.com/litenova/LiteBus/blob/main/Changelog.md#v601") {
-        $errors.Add("Package '$($package.Id)' does not link to the v6.0.1 release notes.")
+    if ($null -eq $releaseNotes -or $releaseNotes.InnerText -ne "https://github.com/litenova/LiteBus/blob/main/Changelog.md#v602") {
+        $errors.Add("Package '$($package.Id)' does not link to the v6.0.2 release notes.")
     }
 
     if ($null -eq $readme -or $readme.InnerText -ne "README.md") {

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,14 +5,14 @@
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <TargetFrameworks>net10.0</TargetFrameworks>
-        <VersionPrefix>6.0.1</VersionPrefix>
+        <VersionPrefix>6.0.2</VersionPrefix>
         <LangVersion>latest</LangVersion>
         <Authors>A. Shafie</Authors>
         <PackageTags>litebus;mediator;messaging;cqrs</PackageTags>
         <PackageIcon>icon.png</PackageIcon>
         <Description>Mediator and durable messaging contracts for explicit command, query, event, inbox, and outbox composition in .NET applications.</Description>
         <PackageProjectUrl>https://litebus.io/</PackageProjectUrl>
-        <PackageReleaseNotes>https://github.com/litenova/LiteBus/blob/main/Changelog.md#v601</PackageReleaseNotes>
+        <PackageReleaseNotes>https://github.com/litenova/LiteBus/blob/main/Changelog.md#v602</PackageReleaseNotes>
         <RepositoryUrl>https://github.com/litenova/LiteBus</RepositoryUrl>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <Nullable>enable</Nullable>

--- a/src/LiteBus.Events/MediationStrategies/AsyncBroadcastMediationStrategy[TMessage].cs
+++ b/src/LiteBus.Events/MediationStrategies/AsyncBroadcastMediationStrategy[TMessage].cs
@@ -206,6 +206,14 @@ public sealed class AsyncBroadcastMediationStrategy<TMessage> : IMessageMediatio
     /// <param name="lazyHandler">The lazily resolved handler and its descriptor.</param>
     /// <param name="executionContext">The execution context set on the ambient scope before the handler runs.</param>
     /// <returns>A task that completes when the handler has finished processing the message.</returns>
+    /// <remarks>
+    ///     <typeparamref name="TMessage" /> is the compile-time message type, which is not always the runtime type of the
+    ///     message. The non-generic <c>IEventMediator.PublishAsync(IEvent, ...)</c> overload erases the event type to
+    ///     <see cref="IEvent" />, and a base-typed variable erases it the same way through the generic overload. Handler
+    ///     contracts are contravariant, so a handler registered for the concrete runtime type does not satisfy a type test
+    ///     against the erased type. Such handlers are invoked through the non-generic entry point, which dispatches to the
+    ///     closed contract the handler actually implements.
+    /// </remarks>
     private static async Task ExecuteSingleHandler(TMessage message,
                                                    LazyHandler<IMessageHandler, IMainHandlerDescriptor> lazyHandler,
                                                    IExecutionContext executionContext)
@@ -223,6 +231,9 @@ public sealed class AsyncBroadcastMediationStrategy<TMessage> : IMessageMediatio
         if (handler is IMessageHandler<TMessage, Task> typedHandler)
         {
             await typedHandler.Handle(message).ConfigureAwait(false);
+            return;
         }
+
+        await ((Task) handler.Handle(message)).ConfigureAwait(false);
     }
 }

--- a/tests/LiteBus.Mediator.UnitTests/UseCases/Events/PolymorphicEventPublishTests.cs
+++ b/tests/LiteBus.Mediator.UnitTests/UseCases/Events/PolymorphicEventPublishTests.cs
@@ -1,0 +1,142 @@
+using LiteBus.Events;
+using LiteBus.Events.Abstractions;
+using LiteBus.Extensions.Microsoft.DependencyInjection;
+using LiteBus.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace LiteBus.Mediator.UnitTests.UseCases.Events;
+
+/// <summary>
+///     Verifies that publishing an event through a base-typed or interface-typed reference still reaches handlers
+///     registered for the concrete runtime type.
+/// </summary>
+/// <remarks>
+///     The base-typed handler subscribes to <see cref="IPolymorphicEvent" /> rather than <see cref="IEvent" /> so that the
+///     events assembly scan used by the other event tests does not pick it up as a handler for every event.
+/// </remarks>
+public sealed class PolymorphicEventPublishTests
+{
+    [Fact]
+    public async Task publishing_through_the_non_generic_overload_invokes_concrete_and_base_typed_handlers()
+    {
+        await using var serviceProvider = BuildServiceProvider();
+        var eventMediator = serviceProvider.GetRequiredService<IEventMediator>();
+        var @event = new SomethingHappened();
+
+        await eventMediator.PublishAsync((IEvent) @event).ConfigureAwait(false);
+
+        @event.ExecutedTypes.Should().BeEquivalentTo([typeof(BaseTypedHandler), typeof(SpecificHandler)]);
+    }
+
+    [Fact]
+    public async Task publishing_through_the_cancellation_token_extension_invokes_concrete_and_base_typed_handlers()
+    {
+        await using var serviceProvider = BuildServiceProvider();
+        var eventMediator = serviceProvider.GetRequiredService<IEventMediator>();
+        var @event = new SomethingHappened();
+
+        await eventMediator.PublishAsync(@event, CancellationToken.None).ConfigureAwait(false);
+
+        @event.ExecutedTypes.Should().BeEquivalentTo([typeof(BaseTypedHandler), typeof(SpecificHandler)]);
+    }
+
+    [Fact]
+    public async Task publishing_through_the_tag_extension_invokes_concrete_and_base_typed_handlers()
+    {
+        await using var serviceProvider = BuildServiceProvider();
+        var eventMediator = serviceProvider.GetRequiredService<IEventMediator>();
+        var @event = new SomethingHappened();
+
+        await eventMediator.PublishAsync((IEvent) @event, "untagged-handlers-always-participate").ConfigureAwait(false);
+
+        @event.ExecutedTypes.Should().BeEquivalentTo([typeof(BaseTypedHandler), typeof(SpecificHandler)]);
+    }
+
+    [Fact]
+    public async Task publishing_through_the_generic_overload_invokes_concrete_and_base_typed_handlers()
+    {
+        await using var serviceProvider = BuildServiceProvider();
+        var eventMediator = serviceProvider.GetRequiredService<IEventMediator>();
+        var @event = new SomethingHappened();
+
+        await eventMediator.PublishAsync(@event, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+
+        @event.ExecutedTypes.Should().BeEquivalentTo([typeof(BaseTypedHandler), typeof(SpecificHandler)]);
+    }
+
+    [Fact]
+    public async Task publishing_through_the_non_generic_overload_honors_the_cancellation_token()
+    {
+        await using var serviceProvider = new ServiceCollection().AddLiteBus(registry =>
+        {
+            registry.AddMessaging(_ =>
+            {
+            });
+
+            registry.AddEvents(builder => builder.Register<TokenCapturingHandler>());
+        }).BuildServiceProvider();
+
+        var eventMediator = serviceProvider.GetRequiredService<IEventMediator>();
+        var @event = new SomethingHappened();
+        using var cancellation = new CancellationTokenSource();
+
+        await eventMediator.PublishAsync((IEvent) @event, cancellationToken: cancellation.Token).ConfigureAwait(false);
+
+        @event.ObservedToken.Should().Be(cancellation.Token);
+    }
+
+    private static ServiceProvider BuildServiceProvider()
+    {
+        return new ServiceCollection().AddLiteBus(registry =>
+        {
+            registry.AddMessaging(_ =>
+            {
+            });
+
+            registry.AddEvents(builder =>
+            {
+                builder.Register<BaseTypedHandler>();
+                builder.Register<SpecificHandler>();
+            });
+        }).BuildServiceProvider();
+    }
+
+    private interface IPolymorphicEvent : IEvent
+    {
+        List<Type> ExecutedTypes { get; }
+    }
+
+    private sealed class SomethingHappened : IPolymorphicEvent
+    {
+        public List<Type> ExecutedTypes { get; } = [];
+
+        public CancellationToken ObservedToken { get; set; }
+    }
+
+    private sealed class BaseTypedHandler : IEventHandler<IPolymorphicEvent>
+    {
+        public Task HandleAsync(IPolymorphicEvent message, CancellationToken cancellationToken = default)
+        {
+            message.ExecutedTypes.Add(GetType());
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class SpecificHandler : IEventHandler<SomethingHappened>
+    {
+        public Task HandleAsync(SomethingHappened message, CancellationToken cancellationToken = default)
+        {
+            message.ExecutedTypes.Add(GetType());
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class TokenCapturingHandler : IEventHandler<SomethingHappened>
+    {
+        public Task HandleAsync(SomethingHappened message, CancellationToken cancellationToken = default)
+        {
+            message.ObservedToken = cancellationToken;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/LiteBus.Storage.Testing/LiteBus.Storage.Testing.csproj
+++ b/tests/LiteBus.Storage.Testing/LiteBus.Storage.Testing.csproj
@@ -5,12 +5,12 @@
         <Description>Cross-provider inbox and outbox store conformance test bases for LiteBus storage adapters.</Description>
         <ImplicitUsings>enable</ImplicitUsings>
         <PackageId>LiteBus.Storage.Testing</PackageId>
-        <VersionPrefix>6.0.1</VersionPrefix>
+        <VersionPrefix>6.0.2</VersionPrefix>
         <PackageTags>litebus;testing;storage;conformance</PackageTags>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageIcon>icon.png</PackageIcon>
         <PackageProjectUrl>https://litebus.io/</PackageProjectUrl>
-        <PackageReleaseNotes>https://github.com/litenova/LiteBus/blob/main/Changelog.md#v601</PackageReleaseNotes>
+        <PackageReleaseNotes>https://github.com/litenova/LiteBus/blob/main/Changelog.md#v602</PackageReleaseNotes>
         <RepositoryUrl>https://github.com/litenova/LiteBus</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/tests/LiteBus.Transport.Testing/LiteBus.Transport.Testing.csproj
+++ b/tests/LiteBus.Transport.Testing/LiteBus.Transport.Testing.csproj
@@ -5,12 +5,12 @@
         <Description>Reusable xUnit conformance tests for LiteBus transport adapter authors.</Description>
         <ImplicitUsings>enable</ImplicitUsings>
         <PackageId>LiteBus.Transport.Testing</PackageId>
-        <VersionPrefix>6.0.1</VersionPrefix>
+        <VersionPrefix>6.0.2</VersionPrefix>
         <PackageTags>litebus;testing;transport;conformance</PackageTags>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageIcon>icon.png</PackageIcon>
         <PackageProjectUrl>https://litebus.io/</PackageProjectUrl>
-        <PackageReleaseNotes>https://github.com/litenova/LiteBus/blob/main/Changelog.md#v601</PackageReleaseNotes>
+        <PackageReleaseNotes>https://github.com/litenova/LiteBus/blob/main/Changelog.md#v602</PackageReleaseNotes>
         <RepositoryUrl>https://github.com/litenova/LiteBus</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## Summary

Fixes #160. Publishing an event through a base-typed or interface-typed reference silently skipped handlers registered for the concrete event type.

`EventMediator.PublishAsync(IEvent, ...)` closes the broadcast strategy over `TMessage == IEvent`. Handler resolution already used `message.GetType()` and produced the right handler list, but `AsyncBroadcastMediationStrategy<TMessage>.ExecuteSingleHandler` only had two contravariant type tests and no else branch, so a handler that matched neither fell off the end of the method and returned a completed task. `IEventHandler<SomethingHappened>` does not satisfy `IAsyncMessageHandler<IEvent>`, so it was dropped with no exception and no log.

This regressed in v6. v4 and v5 invoked handlers via `lazyHandler.Handler.Value.Handle(message)`, which dispatches through the runtime type. The refactor that introduced explicit cancellation-token passing replaced that call with the two type tests and lost the fallback. The equivalent helper for commands and queries (`HandlerInvocation.InvokeMainHandlerAsync<TMessage>`) kept its fallback, which is why only events were affected.

The fix restores the third tier so those handlers dispatch through the non-generic `IMessageHandler.Handle` entry point, whose default implementation casts to the handler's own closed message type and forwards to `HandleAsync`. The cancellation token comes from the ambient execution context, which `ExecuteSingleHandler` scopes from the mediation execution context on the line above, so the caller's token is preserved rather than replaced by `default`. A test asserts that.

Affected call paths beyond the reported one:

- `IEventMediator.PublishAsync(IEvent, ...)` directly.
- The `PublishAsync(@event, cancellationToken)` and `PublishAsync(@event, tag, cancellationToken)` extensions, which bind to the non-generic overload.
- An `IEvent`-typed variable passed to the generic overload, where `TEvent` infers as `IEvent`.
- `EventOutboxDispatcher`, which routes every `IEvent` through the non-generic overload, so in-process outbox dispatch was affected too.

A reflection-based invoker was considered first, to avoid the `AmbiguousImplementationException` a handler implementing several closed contracts would hit on the default-interface-method path. It was dropped: C# rejects `class H : IEventHandler<A>, IEventHandler<B>` at compile time unless the class explicitly implements `IMessageHandler.Handle(object)`, so that hazard cannot reach runtime silently and the extra machinery bought nothing.

## Release

Patch bump to 6.0.2. Version metadata lives in four places, all updated:

- `src/Directory.Build.props` (`VersionPrefix`, `PackageReleaseNotes` anchor).
- `tests/LiteBus.Storage.Testing` and `tests/LiteBus.Transport.Testing`, which are packable but do not inherit `src/Directory.Build.props`.
- `scripts/Test-Packages.ps1`, which asserts every package links to the current release-notes anchor.
- `Changelog.md`, with the exact `## v6.0.2` heading the release workflow requires for tag validation and release-note generation.

## Compatibility and architecture

- [x] Public API or package graph impact is documented. No public API, signature, or package graph change. The only behavioral change is that main handlers previously skipped are now invoked.
- [x] Persisted or transport format impact is documented. None. Persistence schemas and transport behavior are unchanged.
- [x] Dependency role rules remain satisfied. The change is confined to `LiteBus.Events` and adds no references.

Behavioral note for consumers: an application that unknowingly relied on the skip now runs those handlers. That is the v4/v5 behavior and the documented event contract, so it is treated as a fix rather than a break.

## Verification

- [x] `dotnet build LiteBus.slnx --configuration Release`. Clean, 0 warnings, 0 errors, with `TreatWarningsAsErrors` enabled.
- [x] Unit suites in Release: 143 mediator, 92 outbox, 161 inbox, 20 extensions, 256 storage, 71 transport. All passing. Integration suites require Docker and were not run locally; CI covers them.
- [x] `scripts/Test-Documentation.ps1`: 233 Markdown files passed.
- [x] `scripts/Test-DocumentationSemantics.ps1 -Configuration Release`: passed.
- [x] `scripts/Pack-Packages.ps1` at 6.0.2 followed by `scripts/Test-Packages.ps1`: 83 packages and 82 symbol packages validated. This is what caught the two packable projects under `tests/` that carry their own version.
- [x] Documentation and samples were updated when needed. No documentation change was required. `site/content/docs/architecture/handler-resolution.md` already states that `MessageDependencies` resolves both direct and indirect descriptors "so a strategy sees the full set", which is exactly the contract the strategy was violating.

New regression coverage in `tests/LiteBus.Mediator.UnitTests/UseCases/Events/PolymorphicEventPublishTests.cs`: five tests over the non-generic overload, the `CancellationToken` extension (the exact reproduction from the issue), the tag extension, the generic overload, and token propagation. Before the fix three failed and one passed, matching the behavior reported in the issue. After the fix all five pass.

The fixture's base-typed handler subscribes to a test-local `IPolymorphicEvent` rather than `IEvent` on purpose. The events assembly scan in `MediatorTestRegistrationExtensions` matches on namespace prefix and picks up private nested types, so an `IEventHandler<IEvent>` fixture registers as an indirect handler for every other event test and breaks eight of them.

## AI assistance

Per `AI_POLICY.md`: this change was prepared with AI assistance (Claude Code) covering repository navigation, the regression tests, the changelog and documentation prose, and the release-metadata sweep. The diagnosis was verified against the v4.2.0 source of the same method to confirm the regression point, and every check listed above was executed rather than assumed. Maintainer review still owns the decision.
