### PR TITLE
Fix v6.0.3 regressions and prepare patch release

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## v6.0.3
+
+Patch release for .NET 10. Public APIs and persistence schemas are unchanged.
+
+### Fixed
+
+- Lease renewal exceptions now cancel active dispatch and pass the linked cancellation token to the lease store. A blocked or failing renewal no longer leaves a message handler running without lease ownership.
+- Mediation clears the caller's ambient execution context when the mediator returns. Dispatch dependency scopes are created on first handler resolution, so an asynchronous stream that is never enumerated does not create a retained container scope.
+- Asynchronous pre-handler and post-handler reflection now selects the method whose message and result contracts match the current pipeline invocation. A class can implement pipeline contracts for multiple message types without a cached method receiving the wrong message.
+- SQS validates UTF-8 with a strict decoder and checks the broker's allowed Unicode ranges. Invalid UTF-8 and disallowed control bytes use base64 encoding without changing the original bytes. Internal encoding metadata cannot be overridden by caller headers.
+- SQS compacts non-reserved message attributes into `litebus-headers` when a publication would exceed the ten-attribute broker limit. Received messages expand the compact form while preserving route and transport metadata.
+
 ## v6.0.2
 
 Patch release for .NET 10. Public APIs, persistence schemas, and transport behavior are unchanged.

--- a/scripts/Test-Packages.ps1
+++ b/scripts/Test-Packages.ps1
@@ -184,8 +184,8 @@ foreach ($package in $packageMetadata) {
         $errors.Add("Package '$($package.Id)' does not declare the LiteBus website as its project URL.")
     }
 
-    if ($null -eq $releaseNotes -or $releaseNotes.InnerText -ne "https://github.com/litenova/LiteBus/blob/main/Changelog.md#v602") {
-        $errors.Add("Package '$($package.Id)' does not link to the v6.0.2 release notes.")
+    if ($null -eq $releaseNotes -or $releaseNotes.InnerText -ne "https://github.com/litenova/LiteBus/blob/main/Changelog.md#v603") {
+        $errors.Add("Package '$($package.Id)' does not link to the v6.0.3 release notes.")
     }
 
     if ($null -eq $readme -or $readme.InnerText -ne "README.md") {

--- a/site/content/docs/catalog/transport/aws-sqs.md
+++ b/site/content/docs/catalog/transport/aws-sqs.md
@@ -67,7 +67,9 @@ Beta tier note: this adapter is production-oriented but remains Beta while the p
 ## Invariants
 
 - One transport broker adapter per process.
-- Binary body payloads are base64 encoded with `litebus-content-encoding=base64`.
+- SQS-safe UTF-8 text is sent as a plain body. Invalid UTF-8 and code points outside the SQS body ranges are base64 encoded with `litebus-content-encoding=base64`.
+- SQS allows ten message attributes. When route, content type, durable metadata, and caller headers would exceed that limit, non-reserved headers are serialized into the `litebus-headers` attribute and expanded on receive.
+- Mapper-owned attributes such as `litebus-content-encoding`, `litebus-message-id`, `correlation-id`, `Route`, and `ContentType` override conflicting caller values.
 - Redelivery hint uses `ApproximateReceiveCount > 1`.
 
 ## Non-Goals
@@ -111,6 +113,9 @@ Beta tier note: this adapter is production-oriented but remains Beta while the p
 | `CheckAsync_WithoutQueueUrl_ShouldReturnDegraded` | `LiteBus.Transport.UnitTests` (`AwsSqs/`) |
 | `ToSendMessageRequest_ShouldMapBodyAndHeaders` | `LiteBus.Transport.UnitTests` (`AwsSqs/`) |
 | `ToSendMessageRequest_WithBinaryBody_ShouldBase64Encode` | `LiteBus.Transport.UnitTests` (`AwsSqs/`) |
+| `ToSendMessageRequest_WithInvalidUtf8Body_ShouldBase64EncodeWithoutReplacingBytes` | `LiteBus.Transport.UnitTests` (`AwsSqs/`) |
+| `ToSendMessageRequest_WithDisallowedControlByte_ShouldBase64Encode` | `LiteBus.Transport.UnitTests` (`AwsSqs/`) |
+| `ToSendMessageRequest_WithFullDurableMetadata_ShouldPackHeadersAndRoundTripThem` | `LiteBus.Transport.UnitTests` (`AwsSqs/`) |
 | `ToTransportMessage_WithBase64Body_ShouldDecodeBytes` | `LiteBus.Transport.UnitTests` (`AwsSqs/`) |
 | `ComputeRequeueVisibilityTimeout_shouldHonorReceiveCount` | `LiteBus.Transport.UnitTests` (`AwsSqs/`) |
 | `PublishThroughSqs_ShouldAcceptProcessAndDispatchCommand` | `LiteBus.Durable.IntegrationTests` (`Ingress/AwsSqs/`) |

--- a/site/content/docs/integrations/aws-sqs.md
+++ b/site/content/docs/integrations/aws-sqs.md
@@ -70,7 +70,9 @@ The root transport registers `transport.sqs.connectivity`. Configure `Connectivi
 
 ## Wire Encoding
 
-SQS message bodies are strings. UTF-8 JSON and text payloads are sent as plain message bodies. Binary payloads are base64-encoded with a `litebus-content-encoding: base64` message attribute. Correlation identifiers use the canonical `correlation-id` header (`TransportHeaders.CorrelationId`); legacy `CorrelationId` attributes are accepted on ingress only.
+SQS message bodies are strings. LiteBus uses strict UTF-8 decoding and the SQS Unicode ranges before sending a plain body. Invalid UTF-8 and disallowed control bytes are base64-encoded with a `litebus-content-encoding: base64` message attribute, preserving the original bytes. Correlation identifiers use the canonical `correlation-id` header (`TransportHeaders.CorrelationId`); legacy `CorrelationId` attributes are accepted on ingress only.
+
+SQS permits ten message attributes per message. LiteBus keeps mapper-owned route, content type, identifier, correlation, and encoding attributes separate. When the complete header set would exceed ten attributes, the remaining headers are serialized into `litebus-headers`; ingress expands that attribute before contract mapping.
 
 ## Guarantees and Non-Guarantees
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,14 +5,14 @@
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <TargetFrameworks>net10.0</TargetFrameworks>
-        <VersionPrefix>6.0.2</VersionPrefix>
+        <VersionPrefix>6.0.3</VersionPrefix>
         <LangVersion>latest</LangVersion>
         <Authors>A. Shafie</Authors>
         <PackageTags>litebus;mediator;messaging;cqrs</PackageTags>
         <PackageIcon>icon.png</PackageIcon>
         <Description>Mediator and durable messaging contracts for explicit command, query, event, inbox, and outbox composition in .NET applications.</Description>
         <PackageProjectUrl>https://litebus.io/</PackageProjectUrl>
-        <PackageReleaseNotes>https://github.com/litenova/LiteBus/blob/main/Changelog.md#v602</PackageReleaseNotes>
+        <PackageReleaseNotes>https://github.com/litenova/LiteBus/blob/main/Changelog.md#v603</PackageReleaseNotes>
         <RepositoryUrl>https://github.com/litenova/LiteBus</RepositoryUrl>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <Nullable>enable</Nullable>

--- a/src/LiteBus.Messaging.Abstractions/Extensions/MessageContextExtensions.cs
+++ b/src/LiteBus.Messaging.Abstractions/Extensions/MessageContextExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -103,12 +104,24 @@ public static class MessageContextExtensions
     {
         foreach (var postHandler in messageDependencies.PostHandlers)
         {
-            await InvokePostHandlerAsync(postHandler.Handler.Value, message, messageResult, cancellationToken).ConfigureAwait(false);
+            await InvokePostHandlerAsync(
+                    postHandler.Handler.Value,
+                    message,
+                    messageResult,
+                    postHandler.Descriptor.MessageResultType,
+                    cancellationToken)
+                .ConfigureAwait(false);
         }
 
         foreach (var postHandler in messageDependencies.IndirectPostHandlers)
         {
-            await InvokePostHandlerAsync(postHandler.Handler.Value, message, messageResult, cancellationToken).ConfigureAwait(false);
+            await InvokePostHandlerAsync(
+                    postHandler.Handler.Value,
+                    message,
+                    messageResult,
+                    postHandler.Descriptor.MessageResultType,
+                    cancellationToken)
+                .ConfigureAwait(false);
         }
     }
 
@@ -133,15 +146,22 @@ public static class MessageContextExtensions
     /// <param name="handler">The post-handler instance.</param>
     /// <param name="message">The handled message.</param>
     /// <param name="messageResult">The result produced by the main handler, if any.</param>
+    /// <param name="messageResultType">The declared result type associated with the post-handler.</param>
     /// <param name="cancellationToken">The cancellation token for the invocation.</param>
     /// <returns>A task representing the asynchronous post-handler operation.</returns>
     private static Task InvokePostHandlerAsync(
         IMessagePostHandler handler,
         object message,
         object? messageResult,
+        Type messageResultType,
         CancellationToken cancellationToken)
     {
-        return PipelineHandlerInvocation.InvokePostHandlerAsync(handler, message, messageResult, cancellationToken);
+        return PipelineHandlerInvocation.InvokePostHandlerAsync(
+            handler,
+            message,
+            messageResult,
+            messageResultType,
+            cancellationToken);
     }
 
     /// <summary>

--- a/src/LiteBus.Messaging.Abstractions/PipelineHandlerInvocation.cs
+++ b/src/LiteBus.Messaging.Abstractions/PipelineHandlerInvocation.cs
@@ -16,7 +16,7 @@ internal static class PipelineHandlerInvocation
     /// <summary>
     ///     Caches discovered asynchronous pipeline methods per handler runtime type.
     /// </summary>
-    private static readonly ConcurrentDictionary<(Type HandlerType, string MethodName), MethodInfo?> AsyncPipelineMethods = new();
+    private static readonly ConcurrentDictionary<AsyncPipelineMethodKey, MethodInfo?> AsyncPipelineMethods = new();
 
     /// <summary>
     ///     Invokes a pre-handler asynchronously with the supplied cancellation token.
@@ -36,6 +36,7 @@ internal static class PipelineHandlerInvocation
             message,
             () => handler.PreHandle(message),
             [],
+            null,
             cancellationToken);
     }
 
@@ -45,12 +46,14 @@ internal static class PipelineHandlerInvocation
     /// <param name="handler">The post-handler instance.</param>
     /// <param name="message">The handled message.</param>
     /// <param name="messageResult">The result produced by the main handler, if any.</param>
+    /// <param name="messageResultType">The declared result type associated with the post-handler.</param>
     /// <param name="cancellationToken">The cancellation token for the post-handler invocation.</param>
     /// <returns>A task representing the asynchronous post-handler operation.</returns>
     public static Task InvokePostHandlerAsync(
         IMessagePostHandler handler,
         object message,
         object? messageResult,
+        Type messageResultType,
         CancellationToken cancellationToken)
     {
         return InvokeAsyncPipelineMethod(
@@ -59,6 +62,7 @@ internal static class PipelineHandlerInvocation
             message,
             () => handler.PostHandle(message, messageResult),
             [messageResult],
+            messageResultType,
             cancellationToken);
     }
 
@@ -87,6 +91,7 @@ internal static class PipelineHandlerInvocation
     /// <param name="message">The message argument for the handler method.</param>
     /// <param name="fallback">The fallback invocation used when no asynchronous method is found.</param>
     /// <param name="additionalArguments">Additional arguments appended before the cancellation token.</param>
+    /// <param name="messageResultType">The declared post-handler result type, when applicable.</param>
     /// <param name="cancellationToken">The cancellation token passed to the asynchronous method.</param>
     /// <returns>A task representing the handler invocation.</returns>
     private static Task InvokeAsyncPipelineMethod(
@@ -95,11 +100,17 @@ internal static class PipelineHandlerInvocation
         object message,
         Func<object> fallback,
         object?[] additionalArguments,
+        Type? messageResultType,
         CancellationToken cancellationToken)
     {
+        var messageType = message.GetType();
         var method = AsyncPipelineMethods.GetOrAdd(
-            (handler.GetType(), asyncMethodName),
-            key => FindAsyncPipelineMethod(key.HandlerType, key.MethodName));
+            new AsyncPipelineMethodKey(handler.GetType(), asyncMethodName, messageType, messageResultType),
+            key => FindAsyncPipelineMethod(
+                key.HandlerType,
+                key.MethodName,
+                key.MessageType,
+                key.MessageResultType));
 
         if (method is not null)
         {
@@ -120,13 +131,22 @@ internal static class PipelineHandlerInvocation
     }
 
     /// <summary>
-    ///     Finds the first declared asynchronous pipeline method on a handler type.
+    ///     Finds the most specific asynchronous pipeline method on a handler type.
     /// </summary>
     /// <param name="handlerType">The concrete handler runtime type.</param>
     /// <param name="asyncMethodName">The asynchronous method name to locate.</param>
+    /// <param name="messageType">The runtime message type passed to the method.</param>
+    /// <param name="messageResultType">The declared result type passed to a post-handler, when applicable.</param>
     /// <returns>The matching method when found; otherwise, <see langword="null" />.</returns>
-    private static MethodInfo? FindAsyncPipelineMethod(Type handlerType, string asyncMethodName)
+    private static MethodInfo? FindAsyncPipelineMethod(
+        Type handlerType,
+        string asyncMethodName,
+        Type messageType,
+        Type? messageResultType)
     {
+        MethodInfo? bestMethod = null;
+        var bestScore = int.MinValue;
+
         foreach (var handlerInterface in handlerType.GetInterfaces())
         {
             if (!handlerInterface.IsGenericType)
@@ -138,12 +158,50 @@ internal static class PipelineHandlerInvocation
                 asyncMethodName,
                 BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
 
-            if (method is not null && method.ReturnType == typeof(Task))
+            if (method is null || method.ReturnType != typeof(Task))
             {
-                return method;
+                continue;
+            }
+
+            var parameters = method.GetParameters();
+
+            if (parameters.Length < 2 || !parameters[0].ParameterType.IsAssignableFrom(messageType))
+            {
+                continue;
+            }
+
+            var score = parameters[0].ParameterType == messageType ? 1_000 : 500;
+
+            if (messageResultType is not null)
+            {
+                if (parameters.Length < 3 || !parameters[1].ParameterType.IsAssignableFrom(messageResultType))
+                {
+                    continue;
+                }
+
+                score += parameters[1].ParameterType == messageResultType ? 100 : 50;
+            }
+
+            if (score > bestScore)
+            {
+                bestMethod = method;
+                bestScore = score;
             }
         }
 
-        return null;
+        return bestMethod;
     }
+
+    /// <summary>
+    ///     Identifies one cached asynchronous pipeline method by its message and result contract types.
+    /// </summary>
+    /// <param name="HandlerType">The concrete handler runtime type.</param>
+    /// <param name="MethodName">The asynchronous pipeline method name.</param>
+    /// <param name="MessageType">The runtime message type.</param>
+    /// <param name="MessageResultType">The declared post-handler result type, when applicable.</param>
+    private readonly record struct AsyncPipelineMethodKey(
+        Type HandlerType,
+        string MethodName,
+        Type MessageType,
+        Type? MessageResultType);
 }

--- a/src/LiteBus.Messaging/Mediator/LazyMessageDispatchScope.cs
+++ b/src/LiteBus.Messaging/Mediator/LazyMessageDispatchScope.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Threading.Tasks;
+using LiteBus.Runtime.Abstractions;
+
+namespace LiteBus.Messaging.Mediator;
+
+/// <summary>
+///     Defers creation of a dispatch dependency scope until a handler is resolved.
+/// </summary>
+/// <remarks>
+///     Stream mediation can return an asynchronous enumerable that the caller never enumerates. Deferring the host scope
+///     keeps that abandoned result from retaining container-scoped services.
+/// </remarks>
+internal sealed class LazyMessageDispatchScope : IMessageDispatchScope
+{
+    /// <summary>
+    ///     The factory used to create the underlying host scope.
+    /// </summary>
+    private readonly IMessageDispatchScopeFactory _scopeFactory;
+
+    /// <summary>
+    ///     Synchronizes creation and disposal of the underlying scope.
+    /// </summary>
+    private readonly object _gate = new();
+
+    /// <summary>
+    ///     The provider facade that creates the host scope on first service resolution.
+    /// </summary>
+    private readonly IServiceProvider _deferredServiceProvider;
+
+    /// <summary>
+    ///     The underlying scope created on first service resolution.
+    /// </summary>
+    private IMessageDispatchScope? _scope;
+
+    /// <summary>
+    ///     Indicates whether this lazy scope has been disposed.
+    /// </summary>
+    private bool _disposed;
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="LazyMessageDispatchScope" /> class.
+    /// </summary>
+    /// <param name="scopeFactory">The factory used to create the underlying host scope.</param>
+    public LazyMessageDispatchScope(IMessageDispatchScopeFactory scopeFactory)
+    {
+        ArgumentNullException.ThrowIfNull(scopeFactory);
+        _scopeFactory = scopeFactory;
+        _deferredServiceProvider = new DeferredServiceProvider(this);
+    }
+
+    /// <inheritdoc />
+    public IServiceProvider ServiceProvider => _deferredServiceProvider;
+
+    /// <summary>
+    ///     Gets the host provider, creating its scope when the first handler is resolved.
+    /// </summary>
+    /// <returns>The provider for the lazily created host scope.</returns>
+    private IServiceProvider GetScopeProvider()
+    {
+        lock (_gate)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            return (_scope ??= _scopeFactory.CreateScope()).ServiceProvider;
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        IMessageDispatchScope? scope;
+
+        lock (_gate)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            scope = _scope;
+            _scope = null;
+        }
+
+        scope?.Dispose();
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        IMessageDispatchScope? scope;
+
+        lock (_gate)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            scope = _scope;
+            _scope = null;
+        }
+
+        if (scope is not null)
+        {
+            await scope.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    ///     Forwards service resolution to the host provider after creating its scope on demand.
+    /// </summary>
+    private sealed class DeferredServiceProvider : IServiceProvider
+    {
+        /// <summary>
+        ///     The owning lazy dispatch scope.
+        /// </summary>
+        private readonly LazyMessageDispatchScope _owner;
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="DeferredServiceProvider" /> class.
+        /// </summary>
+        /// <param name="owner">The lazy dispatch scope that owns the host provider.</param>
+        public DeferredServiceProvider(LazyMessageDispatchScope owner)
+        {
+            _owner = owner;
+        }
+
+        /// <inheritdoc />
+        public object? GetService(Type serviceType)
+        {
+            ArgumentNullException.ThrowIfNull(serviceType);
+            return _owner.GetScopeProvider().GetService(serviceType);
+        }
+    }
+}

--- a/src/LiteBus.Messaging/Mediator/MediationResourceScope.cs
+++ b/src/LiteBus.Messaging/Mediator/MediationResourceScope.cs
@@ -1,25 +1,19 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using LiteBus.Messaging.Abstractions;
 using LiteBus.Runtime.Abstractions;
 
 namespace LiteBus.Messaging.Mediator;
 
 /// <summary>
-///     Disposes ambient execution context and optional dispatch scopes retained for one mediation call.
+///     Disposes the dispatch scope retained for one mediation call.
 /// </summary>
 internal sealed class MediationResourceScope : IDisposable, IAsyncDisposable
 {
     /// <summary>
-    ///     Gets the ambient execution context scope created for the mediation call.
+    ///     Gets the dispatch scope that owns scoped handler instances.
     /// </summary>
-    private readonly AmbientExecutionContext.ExecutionContextScope _executionScope;
-
-    /// <summary>
-    ///     Gets the dispatch scope that owns scoped handler instances, when one was created.
-    /// </summary>
-    private readonly IMessageDispatchScope? _dispatchScope;
+    private readonly IMessageDispatchScope _dispatchScope;
 
     /// <summary>
     ///     Tracks whether the resource scope has already been disposed.
@@ -29,18 +23,16 @@ internal sealed class MediationResourceScope : IDisposable, IAsyncDisposable
     /// <summary>
     ///     Initializes a new instance of the <see cref="MediationResourceScope" /> class.
     /// </summary>
-    /// <param name="executionScope">The ambient execution context scope created for the mediation call.</param>
-    /// <param name="dispatchScope">The dispatch scope that owns scoped handler instances, when one was created.</param>
+    /// <param name="dispatchScope">The dispatch scope that owns scoped handler instances.</param>
     public MediationResourceScope(
-        AmbientExecutionContext.ExecutionContextScope executionScope,
-        IMessageDispatchScope? dispatchScope)
+        IMessageDispatchScope dispatchScope)
     {
-        _executionScope = executionScope;
+        ArgumentNullException.ThrowIfNull(dispatchScope);
         _dispatchScope = dispatchScope;
     }
 
     /// <summary>
-    ///     Disposes the ambient execution context and dispatch scopes once.
+    ///     Disposes the dispatch scope once.
     /// </summary>
     public void Dispose()
     {
@@ -49,12 +41,11 @@ internal sealed class MediationResourceScope : IDisposable, IAsyncDisposable
             return;
         }
 
-        _executionScope.Dispose();
-        _dispatchScope?.Dispose();
+        _dispatchScope.Dispose();
     }
 
     /// <summary>
-    ///     Asynchronously disposes the ambient execution context and dispatch scopes once.
+    ///     Asynchronously disposes the dispatch scope once.
     /// </summary>
     /// <returns>A value task representing asynchronous dispatch-scope disposal.</returns>
     public async ValueTask DisposeAsync()
@@ -64,11 +55,6 @@ internal sealed class MediationResourceScope : IDisposable, IAsyncDisposable
             return;
         }
 
-        _executionScope.Dispose();
-
-        if (_dispatchScope is not null)
-        {
-            await _dispatchScope.DisposeAsync().ConfigureAwait(false);
-        }
+        await _dispatchScope.DisposeAsync().ConfigureAwait(false);
     }
 }

--- a/src/LiteBus.Messaging/Mediator/MessageMediator.cs
+++ b/src/LiteBus.Messaging/Mediator/MessageMediator.cs
@@ -88,10 +88,10 @@ internal sealed class MessageMediator : IMessageMediator
         // Create a new execution context for the current scope.
         var executionContext = new ExecutionContext(request.Tags, request.Items, cancellationToken);
 
-        // Retain ambient and dispatch scopes until asynchronous mediation results complete.
+        // Retain only the dispatch scope until asynchronous mediation results complete. The ambient scope must not leak
+        // into the caller after this method returns.
         var executionScope = AmbientExecutionContext.CreateScope(executionContext);
-        var dispatchScope = _dispatchScopeFactory.CreateScope();
-        var resourceScope = new MediationResourceScope(executionScope, dispatchScope);
+        var dispatchScope = new LazyMessageDispatchScope(_dispatchScopeFactory);
 
         try
         {
@@ -131,12 +131,16 @@ internal sealed class MessageMediator : IMessageMediator
 
             // Mediate the message using the specified strategy.
             var result = request.MessageMediationStrategy.Mediate(message, messageDependencies, executionContext);
+            executionScope.Dispose();
 
-            return MediationScopeRetention.RetainUntilPipelineCompletes(result, resourceScope);
+            return MediationScopeRetention.RetainUntilPipelineCompletes(
+                result,
+                new MediationResourceScope(dispatchScope));
         }
         catch
         {
-            resourceScope.Dispose();
+            executionScope.Dispose();
+            dispatchScope.Dispose();
             throw;
         }
     }

--- a/src/LiteBus.Messaging/Processing/MessageProcessorLogMessages.cs
+++ b/src/LiteBus.Messaging/Processing/MessageProcessorLogMessages.cs
@@ -54,13 +54,15 @@ internal static class MessageProcessorLogMessages
     /// <param name="processorName">The semantic processor name.</param>
     /// <param name="messageId">The leased message identifier.</param>
     /// <param name="leaseOwner">The owner expected to hold the lease.</param>
+    /// <param name="exception">The renewal exception, when the store call threw.</param>
     public static void LeaseRenewalFailed(
         ILogger logger,
         string processorName,
         Guid messageId,
-        string leaseOwner)
+        string leaseOwner,
+        Exception? exception = null)
     {
-        LeaseRenewalFailedMessage(logger, processorName, messageId, leaseOwner, null);
+        LeaseRenewalFailedMessage(logger, processorName, messageId, leaseOwner, exception);
     }
 
     /// <summary>

--- a/src/LiteBus.Messaging/Processing/ProcessorLeaseHeartbeat.cs
+++ b/src/LiteBus.Messaging/Processing/ProcessorLeaseHeartbeat.cs
@@ -111,16 +111,42 @@ internal static class ProcessorLeaseHeartbeat
         CancellationTokenSource operationCts)
     {
         var expiresAt = context.Clock.GetUtcNow().Add(context.LeaseDuration);
+        bool renewed;
 
-        var renewed = await context.LeaseStore.RenewLeaseAsync(
-                new LeaseRenewalRequest(
+        try
+        {
+            renewed = await context.LeaseStore.RenewLeaseAsync(
+                    new LeaseRenewalRequest(
+                        context.MessageId,
+                        context.LeaseOwner,
+                        context.LeaseGeneration,
+                        context.LeaseDuration,
+                        expiresAt),
+                    operationCts.Token)
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (operationCts.IsCancellationRequested)
+        {
+            return false;
+        }
+#pragma warning disable CA1031 // Lease-store failures must cancel dispatch and be converted to lease loss.
+        catch (Exception exception)
+#pragma warning restore CA1031
+        {
+            if (context.Logger is not null)
+            {
+                MessageProcessorLogMessages.LeaseRenewalFailed(
+                    context.Logger,
+                    context.ProcessorName,
                     context.MessageId,
                     context.LeaseOwner,
-                    context.LeaseGeneration,
-                    context.LeaseDuration,
-                    expiresAt),
-                CancellationToken.None)
-            .ConfigureAwait(false);
+                    exception);
+            }
+
+            context.OnLeaseLost?.Invoke();
+            await operationCts.CancelAsync().ConfigureAwait(false);
+            return false;
+        }
 
         if (renewed)
         {
@@ -133,7 +159,8 @@ internal static class ProcessorLeaseHeartbeat
                 context.Logger,
                 context.ProcessorName,
                 context.MessageId,
-                context.LeaseOwner);
+                context.LeaseOwner,
+                null);
         }
 
         context.OnLeaseLost?.Invoke();

--- a/src/LiteBus.Transport.AwsSqs/SqsMessageMapper.cs
+++ b/src/LiteBus.Transport.AwsSqs/SqsMessageMapper.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Text;
+using System.Text.Json;
 using Amazon.SQS.Model;
 using LiteBus.Transport.Abstractions;
 
@@ -14,6 +15,16 @@ internal static class SqsMessageMapper
     ///     The base64 content encoding marker stored in SQS message attributes.
     /// </summary>
     private const string Base64ContentEncoding = "base64";
+
+    /// <summary>
+    ///     The attribute used to compact LiteBus headers when the SQS attribute limit would be exceeded.
+    /// </summary>
+    private const string PackedHeadersAttribute = "litebus-headers";
+
+    /// <summary>
+    ///     The strict decoder used to validate SQS message body text.
+    /// </summary>
+    private static readonly Encoding StrictUtf8 = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
 
     /// <summary>
     ///     Creates an SQS send request from a LiteBus publish request.
@@ -34,6 +45,8 @@ internal static class SqsMessageMapper
                 ? Convert.ToBase64String(body)
                 : Encoding.UTF8.GetString(body)
         };
+
+        ApplyHeaders(sendRequest, request.Headers);
 
         if (useBase64)
         {
@@ -62,7 +75,12 @@ internal static class SqsMessageMapper
             sendRequest.MessageAttributes["ContentType"] = CreateStringAttribute(request.ContentType);
         }
 
-        ApplyHeaders(sendRequest, request.Headers);
+        if (!useBase64)
+        {
+            sendRequest.MessageAttributes.Remove(TransportHeaders.ContentEncoding);
+        }
+
+        PackHeadersIfNeeded(sendRequest);
         return sendRequest;
     }
 
@@ -82,6 +100,7 @@ internal static class SqsMessageMapper
 
         var body = DecodeBody(message);
         var headers = CopyMessageAttributes(message.MessageAttributes);
+        ExpandPackedHeaders(headers);
 
         return new TransportMessage
         {
@@ -115,7 +134,7 @@ internal static class SqsMessageMapper
             return Convert.FromBase64String(rawBody);
         }
 
-        return Encoding.UTF8.GetBytes(rawBody);
+        return StrictUtf8.GetBytes(rawBody);
     }
 
     /// <summary>
@@ -130,16 +149,46 @@ internal static class SqsMessageMapper
             return true;
         }
 
+        string text;
+
         try
         {
-            var text = Encoding.UTF8.GetString(body);
-
-            return !text.Contains('\0');
+            text = StrictUtf8.GetString(body);
         }
         catch (DecoderFallbackException)
         {
             return false;
         }
+
+        for (var index = 0; index < text.Length; index++)
+        {
+            var codePoint = char.ConvertToUtf32(text, index);
+
+            if (char.IsHighSurrogate(text[index]))
+            {
+                index++;
+            }
+
+            if (!IsAllowedSqsCodePoint(codePoint))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    ///     Returns whether a Unicode scalar is allowed by the SQS message body contract.
+    /// </summary>
+    /// <param name="codePoint">The Unicode scalar to validate.</param>
+    /// <returns><see langword="true" /> when SQS accepts the scalar.</returns>
+    private static bool IsAllowedSqsCodePoint(int codePoint)
+    {
+        return codePoint is 0x9 or 0xA or 0xD ||
+               codePoint is >= 0x20 and <= 0xD7FF ||
+               codePoint is >= 0xE000 and <= 0xFFFD ||
+               codePoint is >= 0x10000 and <= 0x10FFFF;
     }
 
     /// <summary>
@@ -156,7 +205,7 @@ internal static class SqsMessageMapper
 
         foreach (var (name, value) in headers)
         {
-            if (value is null)
+            if (value is null || string.Equals(name, PackedHeadersAttribute, StringComparison.Ordinal))
             {
                 continue;
             }
@@ -164,6 +213,82 @@ internal static class SqsMessageMapper
             sendRequest.MessageAttributes[name] = CreateStringAttribute(
                 Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty);
         }
+    }
+
+    /// <summary>
+    ///     Packs non-reserved attributes when the SQS message attribute limit would be exceeded.
+    /// </summary>
+    /// <param name="sendRequest">The send request whose attributes may be compacted.</param>
+    private static void PackHeadersIfNeeded(SendMessageRequest sendRequest)
+    {
+        if (sendRequest.MessageAttributes.Count <= 10)
+        {
+            return;
+        }
+
+        var packedHeaders = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        foreach (var (name, value) in sendRequest.MessageAttributes.ToArray())
+        {
+            if (IsReservedAttribute(name))
+            {
+                continue;
+            }
+
+            sendRequest.MessageAttributes.Remove(name);
+
+            if (value.StringValue is not null)
+            {
+                packedHeaders[name] = value.StringValue;
+            }
+        }
+
+        sendRequest.MessageAttributes[PackedHeadersAttribute] = CreateStringAttribute(
+            JsonSerializer.Serialize(packedHeaders));
+    }
+
+    /// <summary>
+    ///     Expands a compacted header attribute while preserving reserved attributes already mapped by SQS.
+    /// </summary>
+    /// <param name="headers">The headers copied from SQS message attributes.</param>
+    private static void ExpandPackedHeaders(Dictionary<string, object?> headers)
+    {
+        if (!headers.TryGetValue(PackedHeadersAttribute, out var packedValue) ||
+            packedValue is not string packedHeaders)
+        {
+            return;
+        }
+
+        headers.Remove(PackedHeadersAttribute);
+        var unpackedHeaders = JsonSerializer.Deserialize<Dictionary<string, string>>(packedHeaders);
+
+        if (unpackedHeaders is null)
+        {
+            return;
+        }
+
+        foreach (var (name, value) in unpackedHeaders)
+        {
+            if (!headers.ContainsKey(name))
+            {
+                headers[name] = value;
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Returns whether an attribute is written directly by the SQS mapper and must remain outside packed headers.
+    /// </summary>
+    /// <param name="name">The attribute name.</param>
+    /// <returns><see langword="true" /> for an internal or transport metadata attribute.</returns>
+    private static bool IsReservedAttribute(string name)
+    {
+        return string.Equals(name, PackedHeadersAttribute, StringComparison.Ordinal) ||
+               string.Equals(name, TransportHeaders.ContentEncoding, StringComparison.Ordinal) ||
+               string.Equals(name, TransportHeaders.MessageId, StringComparison.Ordinal) ||
+               string.Equals(name, TransportHeaders.CorrelationId, StringComparison.Ordinal) ||
+               string.Equals(name, "Route", StringComparison.Ordinal) ||
+               string.Equals(name, "ContentType", StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/tests/LiteBus.Mediator.UnitTests/UseCases/Messaging/MediationScopeRetentionTests.cs
+++ b/tests/LiteBus.Mediator.UnitTests/UseCases/Messaging/MediationScopeRetentionTests.cs
@@ -47,6 +47,34 @@ public sealed class MediationScopeRetentionTests : LiteBusTestBase
     }
 
     [Fact]
+    public async Task Mediate_async_result_clears_ambient_context_before_returning()
+    {
+        var registry = new MessageRegistry();
+        registry.Register(typeof(DelayedScopedHandler));
+
+        var services = new ServiceCollection()
+            .AddScoped<ScopedLifetimeMarker>()
+            .AddScoped<DelayedScopedHandler>();
+
+        services.AddLiteBus(registry => registry.AddMessaging(_ => { }));
+
+        using var provider = services.BuildServiceProvider();
+
+        var mediator = new MessageMediator(
+            registry,
+            registry,
+            provider.GetRequiredService<IMessageDispatchScopeFactory>());
+
+        AmbientExecutionContext.ResetForTesting();
+        var mediationTask = mediator.Mediate(new DelayedScopedCommand(), CreateDelayedRequest());
+
+        AmbientExecutionContext.HasCurrent.Should().BeFalse();
+
+        await mediationTask.ConfigureAwait(false);
+        AmbientExecutionContext.HasCurrent.Should().BeFalse();
+    }
+
+    [Fact]
     public async Task Mediate_stream_result_retains_dispatch_scope_until_enumeration_completes()
     {
         var registry = new MessageRegistry();
@@ -91,6 +119,37 @@ public sealed class MediationScopeRetentionTests : LiteBusTestBase
         var secondEnumeration = () => stream.GetAsyncEnumerator();
         secondEnumeration.Should().Throw<InvalidOperationException>()
             .WithMessage("*only once*");
+    }
+
+    [Fact]
+    public void Mediate_unenumerated_stream_does_not_create_dispatch_scope()
+    {
+        var registry = new MessageRegistry();
+        registry.Register(typeof(StreamingScopedHandler));
+
+        var services = new ServiceCollection()
+            .AddScoped<ScopedLifetimeMarker>()
+            .AddScoped<StreamingScopedHandler>();
+
+        services.AddLiteBus(registry => registry.AddMessaging(_ => { }));
+
+        using var provider = services.BuildServiceProvider();
+
+        var factory = new TrackingDispatchScopeFactory(
+            provider.GetRequiredService<IMessageDispatchScopeFactory>());
+        var mediator = new MessageMediator(registry, registry, factory);
+
+        var request = new MessageMediationRequest<StreamingScopedCommand, IAsyncEnumerable<int>>
+        {
+            MessageResolveStrategy = new ActualTypeOrFirstAssignableTypeMessageResolveStrategy(),
+            MessageMediationStrategy = new SingleStreamHandlerMediationStrategy<StreamingScopedCommand, int>(
+                CancellationToken.None),
+            Tags = []
+        };
+
+        _ = mediator.Mediate(new StreamingScopedCommand(), request);
+
+        factory.CreatedCount.Should().Be(0);
     }
 
     [Fact]
@@ -164,6 +223,24 @@ public sealed class MediationScopeRetentionTests : LiteBusTestBase
     private sealed record StreamingScopedCommand : ICommand;
 
     private sealed record NullableStreamingCommand : ICommand;
+
+    private sealed class TrackingDispatchScopeFactory : IMessageDispatchScopeFactory
+    {
+        private readonly IMessageDispatchScopeFactory _inner;
+
+        public TrackingDispatchScopeFactory(IMessageDispatchScopeFactory inner)
+        {
+            _inner = inner;
+        }
+
+        public int CreatedCount { get; private set; }
+
+        public IMessageDispatchScope CreateScope()
+        {
+            CreatedCount++;
+            return _inner.CreateScope();
+        }
+    }
 
     private sealed class ScopedLifetimeMarker : IAsyncDisposable
     {

--- a/tests/LiteBus.Mediator.UnitTests/UseCases/Messaging/MultiContractPipelineHandlerTests.cs
+++ b/tests/LiteBus.Mediator.UnitTests/UseCases/Messaging/MultiContractPipelineHandlerTests.cs
@@ -1,0 +1,146 @@
+using LiteBus.Commands;
+using LiteBus.Commands.Abstractions;
+using LiteBus.Extensions.Microsoft.DependencyInjection;
+using LiteBus.Messaging.Abstractions;
+using LiteBus.Messaging;
+using LiteBus.Testing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace LiteBus.Mediator.UnitTests.UseCases.Messaging;
+
+/// <summary>
+///     Verifies pipeline invocation when one handler implements contracts for multiple message types.
+/// </summary>
+[Collection("Sequential")]
+public sealed class MultiContractPipelineHandlerTests : LiteBusTestBase
+{
+    [Fact]
+    public async Task Send_with_one_pre_and_post_handler_for_two_commands_uses_the_matching_methods()
+    {
+        using var serviceProvider = new ServiceCollection()
+            .AddLiteBus(registry =>
+            {
+                registry.AddMessaging(_ => { });
+                registry.AddCommands(builder =>
+                {
+                    builder.Register<MultiContractPipelineHandler>();
+                    builder.Register<MultiContractCommandAHandler>();
+                    builder.Register<MultiContractCommandBHandler>();
+                    builder.Register<MultiContractCommandA>();
+                    builder.Register<MultiContractCommandB>();
+                });
+            })
+            .BuildServiceProvider();
+
+        var mediator = serviceProvider.GetRequiredService<ICommandMediator>();
+        var commandA = new MultiContractCommandA();
+        var commandB = new MultiContractCommandB();
+
+        await mediator.SendAsync(commandA).ConfigureAwait(false);
+        await mediator.SendAsync(commandB).ConfigureAwait(false);
+
+        commandA.PreHandled.Should().BeTrue();
+        commandA.Handled.Should().BeTrue();
+        commandA.PostHandled.Should().BeTrue();
+        commandB.PreHandled.Should().BeTrue();
+        commandB.Handled.Should().BeTrue();
+        commandB.PostHandled.Should().BeTrue();
+    }
+
+    private sealed class MultiContractPipelineHandler :
+        ICommandPreHandler<MultiContractCommandA>,
+        ICommandPreHandler<MultiContractCommandB>,
+        ICommandPostHandler<MultiContractCommandA>,
+        ICommandPostHandler<MultiContractCommandB>
+    {
+        object IMessagePreHandler.PreHandle(object message)
+        {
+            return message switch
+            {
+                MultiContractCommandA command => PreHandleAsync(command),
+                MultiContractCommandB command => PreHandleAsync(command),
+                _ => throw new ArgumentException("Unsupported command type.", nameof(message))
+            };
+        }
+
+        object IMessagePostHandler.PostHandle(object message, object? messageResult)
+        {
+            return message switch
+            {
+                MultiContractCommandA command => PostHandleAsync(command, messageResult),
+                MultiContractCommandB command => PostHandleAsync(command, messageResult),
+                _ => throw new ArgumentException("Unsupported command type.", nameof(message))
+            };
+        }
+
+        public Task PreHandleAsync(
+            MultiContractCommandA message,
+            CancellationToken cancellationToken = default)
+        {
+            message.PreHandled = true;
+            return Task.CompletedTask;
+        }
+
+        public Task PreHandleAsync(
+            MultiContractCommandB message,
+            CancellationToken cancellationToken = default)
+        {
+            message.PreHandled = true;
+            return Task.CompletedTask;
+        }
+
+        public Task PostHandleAsync(
+            MultiContractCommandA message,
+            object? messageResult,
+            CancellationToken cancellationToken = default)
+        {
+            message.PostHandled = true;
+            return Task.CompletedTask;
+        }
+
+        public Task PostHandleAsync(
+            MultiContractCommandB message,
+            object? messageResult,
+            CancellationToken cancellationToken = default)
+        {
+            message.PostHandled = true;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class MultiContractCommandAHandler : ICommandHandler<MultiContractCommandA>
+    {
+        public Task HandleAsync(MultiContractCommandA message, CancellationToken cancellationToken = default)
+        {
+            message.Handled = true;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class MultiContractCommandBHandler : ICommandHandler<MultiContractCommandB>
+    {
+        public Task HandleAsync(MultiContractCommandB message, CancellationToken cancellationToken = default)
+        {
+            message.Handled = true;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed record MultiContractCommandA : ICommand
+    {
+        public bool PreHandled { get; set; }
+
+        public bool Handled { get; set; }
+
+        public bool PostHandled { get; set; }
+    }
+
+    private sealed record MultiContractCommandB : ICommand
+    {
+        public bool PreHandled { get; set; }
+
+        public bool Handled { get; set; }
+
+        public bool PostHandled { get; set; }
+    }
+}

--- a/tests/LiteBus.Mediator.UnitTests/UseCases/Messaging/ProcessorLeaseHeartbeatTests.cs
+++ b/tests/LiteBus.Mediator.UnitTests/UseCases/Messaging/ProcessorLeaseHeartbeatTests.cs
@@ -71,6 +71,36 @@ public sealed class ProcessorLeaseHeartbeatTests
     }
 
     /// <summary>
+    ///     Verifies a renewal exception cancels active dispatch and passes a cancellable token to the store.
+    /// </summary>
+    [Fact]
+    public async Task RunWithHeartbeatAsync_when_renewal_throws_should_cancel_operation()
+    {
+        var store = new ThrowingRenewLeaseStore();
+
+        var act = () => ProcessorLeaseHeartbeat.RunWithHeartbeatAsync(
+            new LeaseHeartbeatContext(
+                Guid.NewGuid(),
+                "worker",
+                1,
+                store,
+                TimeSpan.FromMinutes(1),
+                TimeSpan.FromMilliseconds(5),
+                new ManualTimeProvider(BaseTime),
+                "test"),
+            async token =>
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, token).ConfigureAwait(false);
+                return 0;
+            },
+            CancellationToken.None);
+
+        var actWithTimeout = () => act().WaitAsync(TimeSpan.FromSeconds(2));
+        await actWithTimeout.Should().ThrowAsync<OperationCanceledException>();
+        store.LastCancellationToken.CanBeCanceled.Should().BeTrue();
+    }
+
+    /// <summary>
     ///     Lease store that always fails renewal.
     /// </summary>
     private sealed class FailingRenewLeaseStore : ILeaseRenewable
@@ -97,6 +127,32 @@ public sealed class ProcessorLeaseHeartbeatTests
         {
             RenewCount++;
             return Task.FromResult(true);
+        }
+    }
+
+    /// <summary>
+    ///     Lease store that succeeds once and throws on the next renewal.
+    /// </summary>
+    private sealed class ThrowingRenewLeaseStore : ILeaseRenewable
+    {
+        private int _renewalAttempts;
+
+        /// <summary>
+        ///     Gets the cancellation token supplied to the latest renewal attempt.
+        /// </summary>
+        public CancellationToken LastCancellationToken { get; private set; }
+
+        /// <inheritdoc />
+        public Task<bool> RenewLeaseAsync(LeaseRenewalRequest request, CancellationToken cancellationToken = default)
+        {
+            LastCancellationToken = cancellationToken;
+
+            if (Interlocked.Increment(ref _renewalAttempts) == 1)
+            {
+                return Task.FromResult(true);
+            }
+
+            throw new InvalidOperationException("renewal failed");
         }
     }
 }

--- a/tests/LiteBus.Storage.Testing/LiteBus.Storage.Testing.csproj
+++ b/tests/LiteBus.Storage.Testing/LiteBus.Storage.Testing.csproj
@@ -5,12 +5,12 @@
         <Description>Cross-provider inbox and outbox store conformance test bases for LiteBus storage adapters.</Description>
         <ImplicitUsings>enable</ImplicitUsings>
         <PackageId>LiteBus.Storage.Testing</PackageId>
-        <VersionPrefix>6.0.2</VersionPrefix>
+        <VersionPrefix>6.0.3</VersionPrefix>
         <PackageTags>litebus;testing;storage;conformance</PackageTags>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageIcon>icon.png</PackageIcon>
         <PackageProjectUrl>https://litebus.io/</PackageProjectUrl>
-        <PackageReleaseNotes>https://github.com/litenova/LiteBus/blob/main/Changelog.md#v602</PackageReleaseNotes>
+        <PackageReleaseNotes>https://github.com/litenova/LiteBus/blob/main/Changelog.md#v603</PackageReleaseNotes>
         <RepositoryUrl>https://github.com/litenova/LiteBus</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/tests/LiteBus.Transport.Testing/LiteBus.Transport.Testing.csproj
+++ b/tests/LiteBus.Transport.Testing/LiteBus.Transport.Testing.csproj
@@ -5,12 +5,12 @@
         <Description>Reusable xUnit conformance tests for LiteBus transport adapter authors.</Description>
         <ImplicitUsings>enable</ImplicitUsings>
         <PackageId>LiteBus.Transport.Testing</PackageId>
-        <VersionPrefix>6.0.2</VersionPrefix>
+        <VersionPrefix>6.0.3</VersionPrefix>
         <PackageTags>litebus;testing;transport;conformance</PackageTags>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageIcon>icon.png</PackageIcon>
         <PackageProjectUrl>https://litebus.io/</PackageProjectUrl>
-        <PackageReleaseNotes>https://github.com/litenova/LiteBus/blob/main/Changelog.md#v602</PackageReleaseNotes>
+        <PackageReleaseNotes>https://github.com/litenova/LiteBus/blob/main/Changelog.md#v603</PackageReleaseNotes>
         <RepositoryUrl>https://github.com/litenova/LiteBus</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/tests/LiteBus.Transport.UnitTests/AwsSqs/SqsMessageMapperTests.cs
+++ b/tests/LiteBus.Transport.UnitTests/AwsSqs/SqsMessageMapperTests.cs
@@ -64,6 +64,133 @@ public sealed class SqsMessageMapperTests
     }
 
     /// <summary>
+    ///     Verifies invalid UTF-8 bytes are preserved through base64 transport encoding.
+    /// </summary>
+    [Fact]
+    public void ToSendMessageRequest_WithInvalidUtf8Body_ShouldBase64EncodeWithoutReplacingBytes()
+    {
+        var binaryBody = new byte[] { 0xC3, 0x28 };
+
+        var sendRequest = SqsMessageMapper.ToSendMessageRequest(new TransportPublishRequest
+        {
+            Destination = "https://sqs.us-east-1.amazonaws.com/123/binary",
+            Body = binaryBody
+        });
+
+        sendRequest.MessageBody.Should().Be(Convert.ToBase64String(binaryBody));
+        sendRequest.MessageAttributes[TransportHeaders.ContentEncoding].StringValue.Should().Be("base64");
+
+        var transportMessage = SqsMessageMapper.ToTransportMessage(
+            new Message
+            {
+                MessageId = "msg-invalid-utf8",
+                Body = sendRequest.MessageBody,
+                MessageAttributes = sendRequest.MessageAttributes
+            },
+            "https://sqs.us-east-1.amazonaws.com/123/binary",
+            new TransportConsumerAckHandlers
+            {
+                AckAsync = _ => Task.CompletedTask,
+                NackAsync = (_, _) => Task.CompletedTask
+            });
+
+        transportMessage.Body.ToArray().Should().Equal(binaryBody);
+    }
+
+    /// <summary>
+    ///     Verifies SQS-disallowed control bytes use the binary body representation.
+    /// </summary>
+    [Fact]
+    public void ToSendMessageRequest_WithDisallowedControlByte_ShouldBase64Encode()
+    {
+        var body = new byte[] { 0x01 };
+
+        var sendRequest = SqsMessageMapper.ToSendMessageRequest(new TransportPublishRequest
+        {
+            Destination = "https://sqs.us-east-1.amazonaws.com/123/control",
+            Body = body
+        });
+
+        sendRequest.MessageBody.Should().Be(Convert.ToBase64String(body));
+        sendRequest.MessageAttributes[TransportHeaders.ContentEncoding].StringValue.Should().Be("base64");
+    }
+
+    /// <summary>
+    ///     Verifies caller headers cannot override the mapper's binary content marker.
+    /// </summary>
+    [Fact]
+    public void ToSendMessageRequest_WithContentEncodingHeaderAndTextBody_ShouldRemoveStaleMarker()
+    {
+        var sendRequest = SqsMessageMapper.ToSendMessageRequest(new TransportPublishRequest
+        {
+            Destination = "https://sqs.us-east-1.amazonaws.com/123/text",
+            Body = Encoding.UTF8.GetBytes("plain text"),
+            Headers = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                [TransportHeaders.ContentEncoding] = "base64"
+            }
+        });
+
+        sendRequest.MessageAttributes.ContainsKey(TransportHeaders.ContentEncoding).Should().BeFalse();
+        sendRequest.MessageBody.Should().Be("plain text");
+    }
+
+    /// <summary>
+    ///     Verifies full durable metadata stays below the SQS ten-attribute limit and expands on receive.
+    /// </summary>
+    [Fact]
+    public void ToSendMessageRequest_WithFullDurableMetadata_ShouldPackHeadersAndRoundTripThem()
+    {
+        var headers = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            [TransportHeaders.MessageId] = "message-1",
+            [TransportHeaders.ContractName] = "orders.events.shipped",
+            [TransportHeaders.ContractVersion] = 2,
+            [TransportHeaders.CorrelationId] = "correlation-1",
+            [TransportHeaders.CausationId] = "causation-1",
+            [TransportHeaders.TenantId] = "tenant-1",
+            [TransportHeaders.TraceContext] = "{\"traceparent\":\"00-test\"}",
+            [TransportHeaders.IdempotencyKey] = "idempotency-1",
+            [TransportHeaders.VisibleAfter] = "2026-06-12T08:00:00.0000000+00:00"
+        };
+
+        var sendRequest = SqsMessageMapper.ToSendMessageRequest(new TransportPublishRequest
+        {
+            Destination = "https://sqs.us-east-1.amazonaws.com/123/orders",
+            Route = "orders.events.shipped",
+            ContentType = "application/json",
+            Body = Encoding.UTF8.GetBytes("{}"),
+            MessageId = "message-1",
+            CorrelationId = "correlation-1",
+            Headers = headers
+        });
+
+        sendRequest.MessageAttributes.Count.Should().BeLessThanOrEqualTo(10);
+        sendRequest.MessageAttributes.Should().ContainKey("litebus-headers");
+
+        var transportMessage = SqsMessageMapper.ToTransportMessage(
+            new Message
+            {
+                MessageId = "aws-message-id",
+                Body = sendRequest.MessageBody,
+                MessageAttributes = sendRequest.MessageAttributes
+            },
+            "https://sqs.us-east-1.amazonaws.com/123/orders",
+            new TransportConsumerAckHandlers
+            {
+                AckAsync = _ => Task.CompletedTask,
+                NackAsync = (_, _) => Task.CompletedTask
+            });
+
+        transportMessage.Headers[TransportHeaders.ContractName].Should().Be("orders.events.shipped");
+        transportMessage.Headers[TransportHeaders.ContractVersion].Should().Be("2");
+        transportMessage.Headers[TransportHeaders.CausationId].Should().Be("causation-1");
+        transportMessage.Headers[TransportHeaders.TenantId].Should().Be("tenant-1");
+        transportMessage.Headers[TransportHeaders.TraceContext].Should().Be("{\"traceparent\":\"00-test\"}");
+        transportMessage.Route.Should().Be("orders.events.shipped");
+    }
+
+    /// <summary>
     ///     Verifies base64-encoded bodies round-trip through consume mapping.
     /// </summary>
     [Fact]


### PR DESCRIPTION
## Summary

This pull request fixes the five regression and release-blocking defects identified after v6.0.2.

- Lease renewal exceptions now cancel active dispatch and pass the linked cancellation token to the lease store. A failing or blocked renewal cannot leave a handler running without a valid lease.
- Mediation restores the caller's ambient execution context before returning. Dispatch dependency scopes are created only when a handler is resolved, so an asynchronous stream that is never enumerated does not retain a container scope.
- Pipeline method lookup selects the method matching the current message and declared result contract. A handler class can implement pre-handler and post-handler contracts for multiple message types.
- SQS uses strict UTF-8 decoding and validates the broker's allowed Unicode ranges. Invalid UTF-8 and disallowed control bytes are base64 encoded without changing the payload bytes.
- SQS mapper-owned attributes cannot be overridden by caller headers. When the ten-attribute SQS limit would be exceeded, non-reserved headers are packed into `litebus-headers` and expanded on receive.
- Version metadata, changelog entries, SQS documentation, and package validation now target v6.0.3.

Public APIs and persistence schemas remain unchanged.

## Tests and verification

- `dotnet build LiteBus.slnx --no-restore`
  - 0 warnings
  - 0 errors
- Unit test suites
  - Mediator: 147 passed
  - Transport: 75 passed
  - Inbox: 161 passed
  - Outbox: 92 passed
  - Runtime: 136 passed
  - Extensions: 20 passed
  - Enterprise: 8 passed
  - Storage: 256 passed
  - Analyzers: 65 passed
  - Total: 960 passed, 0 failed, 0 skipped
- AWS SQS durable integration tests: 16 passed with LocalStack.
- Release packaging through `scripts/Pack-Packages.ps1`: 83 packages and 82 symbol packages validated at version 6.0.3.
- `git diff --check`: passed.

## Release preparation

- `src/Directory.Build.props` now uses `VersionPrefix` 6.0.3.
- Testing package projects use version 6.0.3.
- Package release notes link to the v6.0.3 changelog entry.
- `Changelog.md` documents the fixes and wire-format behavior.
- SQS catalog and integration documentation describe strict body validation and packed headers.

The repository release workflow should use `scripts/Pack-Packages.ps1`, which is also the path used for the successful package validation above. A direct solution-level `dotnet pack LiteBus.slnx` emits NU5017 for the analyzer project; this does not occur with the repository packaging script.

## Scope notes

- The existing result-bearing command overload issue tracked in issue #128 is pre-existing and remains separate from this patch.
- No database schema migration is required.
- No tag or GitHub release was created by this branch.